### PR TITLE
[FE] test: 스토리북 배경 색상을 화이트에서 다크로 변경

### DIFF
--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -1,3 +1,5 @@
+import { colorToken } from '../src/shared/styles/tokens';
+
 import type { Preview } from '@storybook/react-webpack5';
 
 const preview: Preview = {
@@ -8,6 +10,17 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
+    backgrounds: {
+      options: {
+        bg1: { name: 'bg1', value: colorToken.bg[1] },
+        bg2: { name: 'bg2', value: colorToken.bg[2] },
+        dark: { name: 'Dark', value: '#333333' },
+        light: { name: 'Light', value: '#FFFFFF' },
+      },
+    },
+  },
+  initialGlobals: {
+    backgrounds: { value: 'bg1' },
   },
 };
 


### PR DESCRIPTION
# #️⃣ Issue Number
#32 

## 🕹️ 작업 내용

한 줄 요약 : 스토리북 배경 색상을 화이트에서 다크로 변경

- [x] 초기 글로벌 배경을 bg1으로 설정
- [x] colorToken을 사용하여 다양한 배경 옵션(bg1, bg2, dark, light) 추가


## 📋 리뷰 포인트

- 로컬에서 아래와 같이 잘 동작하는지 확인해주세요.
![화면 기록 2025-07-21 오후 8 05 50](https://github.com/user-attachments/assets/e286b732-ba0f-4e1b-ac72-4f3f45fe0f63)


## 🔮 기타 사항

- 감사합니다.
