### PR TITLE
fix: 스토리북 main.ts 설정 파일을 CommonJS에서 ESM 문법으로 변경

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -1,6 +1,10 @@
 import path from 'path';
-
+import { fileURLToPath } from 'url';
 import type { StorybookConfig } from '@storybook/react-webpack5';
+
+// __dirname 대체
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],


### PR DESCRIPTION
좀 더 찾아볼게요 ..^^ 토륵

# #️⃣ Issue Number

#63 

## 🕹️ 작업 내용

한 줄 요약 : 스토리북 main.ts 설정 파일을 CommonJS에서 ESM 문법으로 변경

- [x] __filename 직접 생성
- [x] __dirname 직접 생성

## 📋 리뷰 포인트

- Storybook이 정상적으로 실행되는지 확인해주세요.
-

## 🔮 기타 사항 (참고)

- 문제 상황
  - main.ts는 Storybook이 내부적으로 ESM 방식으로 실행합니다. 
  - ESM 방식은 __dirname과 __filename을 기본적으로 제공하지 않습니다.
- 오류 상황:
  - 현재 ESM 환경이라 "__dirname을 찾을 수 없다"는 오류가 발생했습니다.
- 해결 방법
  -  현재 ESM 환경이라  __dirname를 직접 생성 해줬습니다.

=> 결론: CommonJS 방식은 __dirname를 기본 제공하는데, 우리는 ESM 방식이라 기본 제공 안돼서 오류 발생. 그래서 직접 생성함.