### PR TITLE
[BE] feat: CORS 전역 설정 추가

### DIFF
--- a/backend/src/main/java/com/f12/moitz/common/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/f12/moitz/common/config/WebMvcConfig.java
@@ -1,0 +1,17 @@
+package com.f12.moitz.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
+    }
+
+}

--- a/backend/src/main/java/com/f12/moitz/infrastructure/gemini/GoogleGeminiClient.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/gemini/GoogleGeminiClient.java
@@ -18,7 +18,7 @@ import com.google.genai.types.GenerateContentResponse;
 @Slf4j
 public class GoogleGeminiClient {
 
-    private static final String GEMINI_MODEL = "gemini-1.5-flash-latest";
+    private static final String GEMINI_MODEL = "gemini-2.0-flash";
     private static final int RECOMMENDATION_COUNT = 5;
     private static final String BASIC_PROMPT = """
                     Purpose: Recommend meeting locations where subway travel times from all starting points are similar and distances are not too far.
@@ -119,7 +119,7 @@ public class GoogleGeminiClient {
     private GenerateContentResponse generateBasicContent(String model, String prompt, Map<String, Object> inputData) {
         final GenerateContentConfig config = GenerateContentConfig.builder()
                 .temperature(0.2F)
-//                .maxOutputTokens(5000)
+                .maxOutputTokens(5000)
                 .responseMimeType("application/json")
                 .responseJsonSchema(inputData)
                 .build();


### PR DESCRIPTION
# #️⃣ Issue Number
#65 

## 🕹️ 작업 내용

한 줄 요약 : CORS 전역 설정 추가 및 Gemini 모델 변경 (1.0 flash -> 2.0 flash)

- [x] CORS 전역 설정 추가
- [x] Gemini 모델 변경 (1.0 flash -> 2.0 flash)

## 🔮 기타 사항

- 추후 도메인 구매 후 DNS 설정 시 CORS origin 제한 고려 필요할 수 있어요! 현재는 전역적 허용 해두었습니다.
