### PR TITLE
[BE] chore: CI/CD 스크립트 분리

### DIFF
--- a/.github/workflows/be-cicd-dev-auto-trigger.yml
+++ b/.github/workflows/be-cicd-dev-auto-trigger.yml
@@ -1,10 +1,17 @@
-name: Backend 개발 서버 CI/CD
+name: Backend 개발 서버 CI/CD (Auto-trigger)
 
 on:
-  workflow_dispatch:
+  pull_request:
+    branches:
+      - dev
+    types:
+      - closed
+    paths:
+      - "backend/**"
 
 jobs:
   deploy:
+    if: github.event.pull_request.merged == true
     runs-on: [ self-hosted ]
     steps:
       - name: 최신 커밋 내역으로 checkout 한다


### PR DESCRIPTION
# #️⃣ Issue Number
#57 

## 🕹️ 작업 내용

한 줄 요약 : dev 브랜치의 수동 배포를 위해 workflow 스크립트를 분리했습니다.

- [x] dev 브랜치도 수동으로 배포할 수 있도록 trigger 조건을 각각 다른 workflow로 분리

## 📋 리뷰 포인트

- 스크립트 분리 시 if 조건 등의 세부 내용을 혼동하지 않았는지