### PR TITLE
[FE] feat: 의도하지 않은 경로로 들어오면 에러 페이지를 보여줌

### DIFF
--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -1,16 +1,29 @@
 import { createElement } from 'react';
+import { MemoryRouter } from 'react-router';
 
 import GlobalStyle from '../src/shared/styles/GlobalStyle';
 import { colorToken } from '../src/shared/styles/tokens';
 
-import type { Decorator } from '@storybook/react';
+import type { Decorator, StoryContext } from '@storybook/react';
 import type { Preview } from '@storybook/react-webpack5';
 
+// 글로벌 스타일 적용
 const withGlobalStyle: Decorator = (Story) => {
   return createElement(
     'div',
     null,
     createElement(GlobalStyle),
+    createElement(Story),
+  );
+};
+
+// 라우팅 적용
+const withMemoryRouter: Decorator = (Story, context: StoryContext) => {
+  const path = context.parameters?.pathname ?? '/';
+
+  return createElement(
+    MemoryRouter,
+    { initialEntries: [path] },
     createElement(Story),
   );
 };
@@ -35,7 +48,7 @@ const preview: Preview = {
   initialGlobals: {
     backgrounds: { value: 'bg1' },
   },
-  decorators: [withGlobalStyle],
+  decorators: [withMemoryRouter, withGlobalStyle],
 };
 
 export default preview;

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,6 +1,7 @@
 import { Route, Routes } from 'react-router';
 
 import IndexPage from '@pages/indexPage/IndexPage';
+import NotFoundPage from '@pages/notFoundPage/NotFoundPage';
 import ResultPage from '@pages/resultPage/ResultPage';
 
 export default function App() {
@@ -8,6 +9,7 @@ export default function App() {
     <Routes>
       <Route path="/" element={<IndexPage />} />
       <Route path="/result" element={<ResultPage />} />
+      <Route path="*" element={<NotFoundPage />} />
     </Routes>
   );
 }

--- a/frontend/src/pages/notFoundPage/NotFoundPage.tsx
+++ b/frontend/src/pages/notFoundPage/NotFoundPage.tsx
@@ -1,0 +1,37 @@
+import { Link } from 'react-router';
+
+import { flex, typography } from '@shared/styles/default.styled';
+
+import * as notFoundPage from './notFoundPage.styled';
+
+function NotFoundPage() {
+  return (
+    <div
+      css={[
+        flex({
+          direction: 'column',
+          justify: 'center',
+          align: 'center',
+          gap: 40,
+        }),
+        notFoundPage.base,
+      ]}
+    >
+      <p css={typography.h1}>죄송합니다. 페이지를 사용할 수 없습니다.</p>
+      <div
+        css={flex({
+          direction: 'column',
+          justify: 'center',
+          align: 'center',
+        })}
+      >
+        <span css={typography.b1}>
+          클릭하신 링크가 잘못되었거나 페이지가 삭제되었습니다.
+        </span>
+        <Link to="/">모잇지로 돌아가기.</Link>
+      </div>
+    </div>
+  );
+}
+
+export default NotFoundPage;

--- a/frontend/src/pages/notFoundPage/NotFoundPage.tsx
+++ b/frontend/src/pages/notFoundPage/NotFoundPage.tsx
@@ -14,7 +14,7 @@ function NotFoundPage() {
           align: 'center',
           gap: 40,
         }),
-        notFoundPage.base,
+        notFoundPage.base(),
       ]}
     >
       <p css={typography.h1}>죄송합니다. 페이지를 사용할 수 없습니다.</p>

--- a/frontend/src/pages/notFoundPage/notFoundPage.styled.ts
+++ b/frontend/src/pages/notFoundPage/notFoundPage.styled.ts
@@ -1,0 +1,5 @@
+import { css } from '@emotion/react';
+
+export const base = () => css`
+  padding: 40px 20px;
+`;

--- a/frontend/src/pages/pages.stories.tsx
+++ b/frontend/src/pages/pages.stories.tsx
@@ -1,0 +1,33 @@
+import App from '../app/App';
+
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+
+const meta: Meta<typeof App> = {
+  title: 'Pages',
+  component: App,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof App>;
+
+export const Index: Story = {
+  parameters: {
+    pathname: '/',
+  },
+};
+
+export const Result: Story = {
+  parameters: {
+    pathname: '/result',
+  },
+};
+
+export const NotFound: Story = {
+  parameters: {
+    pathname: '/NotFound',
+  },
+};


### PR DESCRIPTION
# #️⃣ Issue Number

#98 

## 🕹️ 작업 내용

한 줄 요약 : 의도하지 않은 경로로 들어오면 에러 페이지를 보여줌

[스토리북](https://www.chromatic.com/build?appId=687b15d60d246cbdd1965dd5&number=10)

- preview.ts에 스토리북에서 라우팅이 정상적으로 동작하도록 기본 설정을 추가했습니다.
- `*` 경로 (지정한 경로 외의 경로)로 들어오면 NotFoundPage로 가도록 라우팅 했습니다.
- 디자인은 가볍게 인스타그램을 참고해서 만들었습니다. (디자인 피드백 환영)

## 📋 리뷰 포인트

- [ ] / 경로로 들어오면 IndexPage를 보여준다.
- [ ] result 경로로 들어오면 ResultPage를 보여준다.
- [ ] 그 외 경로로 들어오면 NotFoundPage를 보여준다.

## 🔮 기타 사항

- Webpack 환경에서는 `BrowserRouter`를 사용했지만, 스토리북에서 `MemoryRouter`를 사용한 이유는?
  - 스토리북은 실제 브라우저 라우팅 환경이 아닙니다.
  - 그래서 Storybook은 iframe 안에서 컴포넌트를 렌더링하므로 실제 주소창 URL과 무관하게 동작해야 합니다.
  - BrowserRouter는 window.location을 필요로 합니다. → 스토리북 내에서는 비정상 동작성이 있습니다.
-  MemoryRouter의 장점은?
  -  초기 경로를 자유롭게 설정할 수 있습니다.
 - 예를 들어, MemoryRouter는 initialEntries: ['/result'] 같은 설정으로 원하는 경로에서 컴포넌트를 시작할 수 있어 테스트/문서화에 유리합니다.

```tsx
// main.tsx (Webpack 환경)

    <BrowserRouter>
      <Layout>
        <App />
      </Layout>
    </BrowserRouter>
```

```tsx
// preview.tsx (스토리북 환경)

    <BrowserRouter>
      <Layout>
        <App />
      </Layout>
    </BrowserRouter>
```