### PR TITLE
chore: PR 머지 시 자동으로 이슈를 닫는 GitHub Actions 워크플로우 추가

### DIFF
--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -1,0 +1,38 @@
+name: Auto Close Issues
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true # PR이 머지된 경우에만 실행
+
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+
+            // Issue Number 섹션에서 이슈 번호 추출
+            const issueSection = body.split('# #️⃣ Issue Number')[1];
+            if (!issueSection) return;
+
+            const nextSection = issueSection.split('#')[0];  // 다음 섹션 전까지
+            const issues = nextSection.match(/#(\d+)/g) || [];
+
+            for (const issue of issues) {
+              const num = issue.replace('#', '');
+              try {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: parseInt(num),
+                  state: 'closed'
+                });
+                console.log(`Successfully closed issue #${num}`);
+              } catch (error) {
+                console.error(`Failed to close issue #${num}:`, error);
+              }
+            }


### PR DESCRIPTION
# #️⃣ Issue Number
#106 

## 🕹️ 작업 내용

한 줄 요약 : PR 머지 시 연관된 이슈를 자동으로 닫는 GitHub Actions 워크플로우 추가

- [x] `auto-close-issues.yml` 워크플로우 파일 생성
- [x] PR 템플릿의 Issue Number 섹션과 연동

## 📋 리뷰 포인트

- PR이 머지될 때만 워크플로우가 동작하도록 설정했습니다 (단순 close는 제외)
- PR 템플릿의 'Issue Number' 섹션에서만 이슈 번호를 추출합니다
- 에러 처리를 추가하여 일부 이슈 닫기가 실패해도 나머지 이슈는 계속 처리됩니다

  <details>
  <summary>워크플로우 동작 방식 상세 설명</summary>
  
  코드 가독성을 위해 실제 워크플로우 파일에는 주석을 최소화했습니다.
  아래는 각 단계별 동작 방식에 대한 상세 설명입니다:
  
  1. **트리거 조건**
     - PR이 닫힐 때 워크플로우가 시작됩니다
     - PR이 실제로 머지된 경우에만 실행됩니다 (`if: github.event.pull_request.merged == true`)
  
  2. **이슈 번호 추출 과정**
     - PR 템플릿의 'Issue Number' 섹션을 파싱합니다
     - 다음 섹션 시작 전까지의 텍스트에서 이슈 번호를 추출합니다
     - `#숫자` 형식의 모든 이슈 번호를 찾습니다
  
  3. **이슈 처리 방식**
     - GitHub API를 사용하여 각 이슈의 상태를 'closed'로 업데이트합니다
     - 각 이슈별로 독립적으로 처리되어 한 이슈의 실패가 다른 이슈에 영향을 주지 않습니다
     - 성공/실패 여부를 로그로 기록합니다
  
  ```yml
  name: Auto Close Issues
  
  # PR이 닫힐 때 자동으로 연관된 이슈를 닫는 워크플로우
  # PR 템플릿의 'Issue Number' 섹션에서 이슈 번호를 추출하여 처리
  
  on:
    pull_request:
      types: [closed] # PR이 닫힐 때 트리거
  
  jobs:
    close-issues:
      runs-on: ubuntu-latest
      if: github.event.pull_request.merged == true # PR이 머지된 경우에만 실행
  
      steps:
        # GitHub API를 사용하여 이슈를 자동으로 닫는 스크립트 실행
        - uses: actions/github-script@v7
          with:
            script: |
              // PR 본문 가져오기 (비어있을 경우 빈 문자열 사용)
              const body = context.payload.pull_request.body || '';
  
              // PR 템플릿에서 'Issue Number' 섹션 추출
              // '# #️⃣ Issue Number' 이후의 텍스트를 가져옴
              const issueSection = body.split('# #️⃣ Issue Number')[1];
              if (!issueSection) return;  // 섹션이 없으면 종료
  
              // 다음 섹션 시작 전까지의 텍스트만 추출
              const nextSection = issueSection.split('#')[0];
              // 텍스트에서 이슈 번호(#숫자 형식) 추출
              const issues = nextSection.match(/#(\d+)/g) || [];
  
              // 각 이슈에 대해 처리
              for (const issue of issues) {
                const num = issue.replace('#', '');  // '#' 제거하여 숫자만 추출
                try {
                  // GitHub API를 사용하여 이슈 상태를 'closed'로 업데이트
                  await github.rest.issues.update({
                    owner: context.repo.owner,
                    repo: context.repo.repo,
                    issue_number: parseInt(num),
                    state: 'closed'
                  });
                  console.log(`Successfully closed issue #${num}`);
                } catch (error) {
                  // 이슈 닫기 실패 시 에러 로깅
                  console.error(`Failed to close issue #${num}:`, error);
                }
              }
  
  ```
  
  </details>

## 🔮 기타 사항

- 워크플로우 테스트를 위해 `common/chore-issue-close` 브랜치에서 먼저 검증 후, 정상 동작 확인되면 `dev` 브랜치로 머지할 예정입니다.