### PR TITLE
[FE] chore: PR이 머지되면 이슈가 닫히도록 설정

### DIFF
--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  issues: write
+  pull-requests: read
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# #️⃣ Issue Number
#106 

## 🕹️ 작업 내용

한 줄 요약 : GitHub Actions workflow에 이슈 관련 권한 추가

- [x] `permissions` 설정 추가 (`issues: write`, `pull-requests: read`)

## 📋 리뷰 포인트

- workflow가 이슈를 닫을 수 있도록 필요한 최소 권한만 추가했습니다

## 🔮 기타 사항

- 권한 추가로 인해 이전에 실패하던 이슈 자동 닫기가 정상 동작할 것으로 예상됩니다