### PR TITLE
[FE] chore: PR이 머지되면 이슈가 닫히도록 설정

### DIFF
--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -1,7 +1,7 @@
 name: Auto Close Issues
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions:


### PR DESCRIPTION
# #️⃣ Issue Number
#106 

## 🕹️ 작업 내용

한 줄 요약 : 자동 이슈 닫기 워크플로우의 이벤트 타입을 pull_request_target으로 변경

- [x] `pull_request` → `pull_request_target` 이벤트 타입 변경

## 📋 리뷰 포인트

- fork된 레포지토리의 PR에서도 워크플로우가 동작하도록 이벤트 타입을 변경했습니다
- 이전 PR (#107)에서 워크플로우가 동작하지 않던 문제를 해결합니다

## 🔮 기타 사항

- 변경사항 적용 후 PR 머지 시 이슈가 자동으로 닫히는지 확인이 필요합니다