### PR TITLE
[FE] chore: 자동 이슈 닫기 워크플로우의 이벤트 타입을 pull_request로 변경 및 이슈 번호 추출 로직 간소화

### DIFF
--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -1,12 +1,8 @@
 name: Auto Close Issues
 
 on:
-  pull_request_target:
+  pull_request:
     types: [closed]
-
-permissions:
-  issues: write
-  pull-requests: read
 
 jobs:
   close-issues:
@@ -18,13 +14,7 @@ jobs:
         with:
           script: |
             const body = context.payload.pull_request.body || '';
-
-            // Issue Number 섹션에서 이슈 번호 추출
-            const issueSection = body.split('# #️⃣ Issue Number')[1];
-            if (!issueSection) return;
-
-            const nextSection = issueSection.split('#')[0];  // 다음 섹션 전까지
-            const issues = nextSection.match(/#(\d+)/g) || [];
+            const issues = body.match(/#(\d+)/g) || [];
 
             for (const issue of issues) {
               const num = issue.replace('#', '');


### PR DESCRIPTION
# #️⃣ Issue Number
#111 

## 🕹️ 작업 내용

한 줄 요약 : 자동 이슈 닫기 워크플로우의 이벤트 타입 변경 및 로직 개선

- [x] 이벤트 타입을 `pull_request_target`에서 `pull_request`로 변경
- [x] 이슈 번호 추출 로직을 전체 PR 본문에서 찾도록 간소화
- [x] 불필요한 `permissions` 설정 제거

## 📋 리뷰 포인트

- 이전 PR들에서 워크플로우가 정상 동작하지 않던 문제를 해결했습니다
- 다른 팀의 동작하는 코드를 참고하여 불필요한 복잡성을 제거했습니다
- 에러 처리(`try-catch`)는 안정성을 위해 유지했습니다

## 🔮 기타 사항

- PR이 머지된 경우에만 이슈가 닫히도록 하는 조건(`if: github.event.pull_request.merged == true`)은 유지했습니다