### PR TITLE
[FE] chore: 자동 이슈 닫기 워크플로우 동작하지 않는 문제 수정

### DIFF
--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  issues: write
+  pull-requests: read
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# #️⃣ Issue Number
#111 

## 🕹️ 작업 내용

한 줄 요약 : 자동 이슈 닫기 워크플로우에 필요한 권한 설정 추가

- [x] GitHub Actions에 이슈 수정 권한(`issues: write`) 추가
- [x] GitHub Actions에 PR 읽기 권한(`pull-requests: read`) 추가

## 📋 리뷰 포인트

- 이전 PR에서 워크플로우가 403 에러(권한 없음)로 실패하는 문제를 해결합니다
- 워크플로우가 필요로 하는 최소한의 권한만 부여했습니다
  - `issues: write`: 이슈를 닫기 위한 권한
  - `pull-requests: read`: PR 본문을 읽기 위한 권한

## 🔮 기타 사항

- 이전 PR에서 제거했던 `permissions` 설정이 실제로는 필요한 설정이었음이 확인되었습니다