### PR TITLE
[FE] chore: 자동 이슈 닫기 워크플로우 동작하지 않는 문제 수정

### DIFF
--- a/.github/workflows/auto-close-issues.yml
+++ b/.github/workflows/auto-close-issues.yml
@@ -1,7 +1,7 @@
 name: Auto Close Issues
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions:


### PR DESCRIPTION
# #️⃣ Issue Number
#111 

## 🕹️ 작업 내용

한 줄 요약 : fork된 레포지토리의 PR에서도 이슈가 자동으로 닫히도록 수정

- [x] 이벤트 타입을 `pull_request_target`으로 변경
- [x] 워크플로우 권한 설정 유지 (`permissions`)

## 📋 리뷰 포인트

- fork된 레포지토리의 PR에서 발생하는 403 권한 에러를 해결합니다
- 기존 권한 설정은 유지하면서 이벤트 타입만 변경했습니다

## 🔮 기타 사항

- 이전 PR들에서 발생한 권한 문제가 해결될 것으로 예상됩니다