### PR TITLE
[FE] chore: import 별칭에 mock 추가

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -54,9 +54,10 @@ const config: StorybookConfig = {
         '@shared/styles': path.resolve(__dirname, '../src/shared/styles'),
         '@shared/types': path.resolve(__dirname, '../src/shared/types'),
         '@icons': path.resolve(__dirname, '../assets/icon'),
+        '@mocks': path.resolve(__dirname, '../src/mocks'),
       };
     }
-    
+
     return config;
   },
 };

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -38,17 +38,20 @@ export default [
     rules: {
       // JavaScript 기본 권장 규칙들
       ...js.configs.recommended.rules,
-  
-      // TypeScript ESLint 권장 규칙들  
+
+      // TypeScript ESLint 권장 규칙들
       ...tseslint.configs.recommended.rules,
-  
+
       // React 권장 규칙들
       ...pluginReact.configs.recommended.rules,
-  
+
       // 커스텀 규칙들
       'react/react-in-jsx-scope': 'off',
       'react/jsx-uses-react': 'off',
-      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_' },
+      ],
 
       // emotion css prop를 쓰기 위한 규칙
       'react/no-unknown-property': ['error', { ignore: ['css'] }],
@@ -109,6 +112,12 @@ export default [
             // 6. assets
             {
               pattern: '@icons/**',
+              group: 'internal',
+              position: 'before',
+            },
+            // 7. mocks
+            {
+              pattern: '@mocks/**',
               group: 'internal',
               position: 'before',
             },

--- a/frontend/src/features/recommendation/components/bottomSheet/bottomSheet.stories.ts
+++ b/frontend/src/features/recommendation/components/bottomSheet/bottomSheet.stories.ts
@@ -1,5 +1,5 @@
-import recommendedLocationsMock from '../../../../mocks/recommendedLocationsMock';
-import startingLocationsMock from '../../../../mocks/startingLocationsMock';
+import recommendedLocationsMock from '@mocks/recommendedLocationsMock';
+import startingLocationsMock from '@mocks/startingLocationsMock';
 
 import BottomSheet from './BottomSheet';
 

--- a/frontend/src/features/recommendation/components/spotItemList/spotItemList.stories.ts
+++ b/frontend/src/features/recommendation/components/spotItemList/spotItemList.stories.ts
@@ -1,4 +1,4 @@
-import recommendedLocationMock from '../../../../mocks/recommendedLocationsMock';
+import recommendedLocationMock from '@mocks/recommendedLocationsMock';
 
 import SpotItemList from './SpotItemList';
 

--- a/frontend/src/pages/resultPage/ResultPage.tsx
+++ b/frontend/src/pages/resultPage/ResultPage.tsx
@@ -3,8 +3,8 @@ import BottomSheet from '@features/recommendation/components/bottomSheet/BottomS
 
 import { flex } from '@shared/styles/default.styled';
 
-import recommendedLocationsMock from '../../mocks/recommendedLocationsMock';
-import startingLocationsMock from '../../mocks/startingLocationsMock';
+import recommendedLocationsMock from '@mocks/recommendedLocationsMock';
+import startingLocationsMock from '@mocks/startingLocationsMock';
 
 import * as resultPage from './resultPage.styled';
 

--- a/frontend/src/shared/components/startingSpotName/startingSpotName.stories.ts
+++ b/frontend/src/shared/components/startingSpotName/startingSpotName.stories.ts
@@ -1,4 +1,4 @@
-import startingLocationsMock from '../../../mocks/startingLocationsMock';
+import startingLocationsMock from '@mocks/startingLocationsMock';
 
 import StartingSpotName from './StartingSpotName';
 

--- a/frontend/src/shared/components/startingSpotWrapper/startingSpotWrapper.stories.ts
+++ b/frontend/src/shared/components/startingSpotWrapper/startingSpotWrapper.stories.ts
@@ -1,4 +1,4 @@
-import startSpotNameListMock from '../../../mocks/startingLocationsMock';
+import startSpotNameListMock from '@mocks/startingLocationsMock';
 
 import StartingSpotWrapper from './StartingSpotWrapper';
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -41,6 +41,9 @@
       ],
       "@icons/*": [
         "assets/icon/*"
+      ],
+      "@mocks/*": [
+        "src/mocks/*"
       ]
     }
   },

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -4,7 +4,6 @@ const dotenv = require('dotenv');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 
-
 // .env 파일 읽기
 const envVars = dotenv.config().parsed || {};
 
@@ -67,6 +66,7 @@ const config = {
       '@shared/styles': path.resolve(__dirname, 'src/shared/styles'),
       '@shared/types': path.resolve(__dirname, 'src/shared/types'),
       '@icons': path.resolve(__dirname, 'assets/icon'),
+      '@mocks': path.resolve(__dirname, 'src/mocks'),
     },
   },
 };


### PR DESCRIPTION
# #️⃣ Issue Number
#119 

## 🕹️ 작업 내용

한 줄 요약 : 모듈 경로 별칭 '@mocks' 추가 및 관련 설정 업데이트

- [x] webpack, tsconfig에 '@mocks' 경로 별칭 추가
- [x] ESLint import/order 규칙에 '@mocks' 설정 추가

## 📋 리뷰 포인트

- `@mocks` 경로가 webpack과 tsconfig에 올바르게 설정되었는지 확인 부탁드립니다
- ESLint import/order 규칙에서 `@mocks`가 마지막 순서로 적절하게 배치되었는지 확인 부탁드립니다

## 🔮 기타 사항

- 기존 상대 경로를 사용하던 mock 파일들의 import 구문을 `@mocks`로 변경했습니다