### PR TITLE
feat: [공통 컴포넌트] 마커 인덱스 컴포넌트를 피그마 수정에 맞게 props 추가

### DIFF
--- a/frontend/src/shared/components/markerIndex/MarkerIndex.tsx
+++ b/frontend/src/shared/components/markerIndex/MarkerIndex.tsx
@@ -43,7 +43,7 @@ function MarkerIndex({
           hasShadow && shadow.map,
         ]}
       >
-        <span css={typography.h3}>{index}</span>
+        <span css={[typography.h3, marker.circle_font()]}>{index}</span>
       </div>
       {label && <p css={[label_base(), label_type()]}>{label}</p>}
     </div>

--- a/frontend/src/shared/components/markerIndex/MarkerIndex.tsx
+++ b/frontend/src/shared/components/markerIndex/MarkerIndex.tsx
@@ -4,7 +4,7 @@ import * as marker from './markerIndex.styled';
 import { label_base } from './markerIndex.styled';
 
 interface MarkerIndexProps {
-  index: number;
+  index: number | string;
   type: 'recommended' | 'starting';
   label?: string;
   hasStroke?: boolean;

--- a/frontend/src/shared/components/markerIndex/MarkerIndex.tsx
+++ b/frontend/src/shared/components/markerIndex/MarkerIndex.tsx
@@ -1,7 +1,6 @@
 import { flex, typography, shadow } from '@shared/styles/default.styled';
 
 import * as marker from './markerIndex.styled';
-import { label_base } from './markerIndex.styled';
 
 interface MarkerIndexProps {
   index: number | string;
@@ -45,7 +44,7 @@ function MarkerIndex({
       >
         <span css={[typography.h3, marker.circle_font()]}>{index}</span>
       </div>
-      {label && <p css={[label_base(), label_type()]}>{label}</p>}
+      {label && <p css={[marker.label_base(), label_type()]}>{label}</p>}
     </div>
   );
 }

--- a/frontend/src/shared/components/markerIndex/MarkerIndex.tsx
+++ b/frontend/src/shared/components/markerIndex/MarkerIndex.tsx
@@ -1,22 +1,51 @@
-import { flex, typography } from '@shared/styles/default.styled';
+import { flex, typography, shadow } from '@shared/styles/default.styled';
 
 import * as marker from './markerIndex.styled';
+import { label_base } from './markerIndex.styled';
 
 interface MarkerIndexProps {
   index: number;
+  type: 'recommended' | 'starting';
+  label?: string;
   hasStroke?: boolean;
+  hasShadow?: boolean;
 }
 
-function MarkerIndex({ index, hasStroke = false }: MarkerIndexProps) {
+function MarkerIndex({
+  index,
+  type,
+  label = '',
+  hasStroke = false,
+  hasShadow = false,
+}: MarkerIndexProps) {
+  const circle_type =
+    type === 'recommended' ? marker.circle_recommended : marker.circle_starting;
+  const label_type =
+    type === 'recommended' ? marker.label_recommended : marker.label_starting;
+
   return (
     <div
       css={[
-        flex({ justify: 'center', align: 'center' }),
-        marker.base(),
-        hasStroke && marker.stroke(),
+        flex({
+          direction: 'column',
+          justify: 'center',
+          align: 'center',
+          gap: 5,
+        }),
       ]}
     >
-      <span css={typography.h3}>{index}</span>
+      <div
+        css={[
+          flex({ justify: 'center', align: 'center' }),
+          marker.circle_base(),
+          circle_type(),
+          hasStroke && marker.stroke(),
+          hasShadow && shadow.map,
+        ]}
+      >
+        <span css={typography.h3}>{index}</span>
+      </div>
+      {label && <p css={[label_base(), label_type()]}>{label}</p>}
     </div>
   );
 }

--- a/frontend/src/shared/components/markerIndex/MarkerIndex.tsx
+++ b/frontend/src/shared/components/markerIndex/MarkerIndex.tsx
@@ -29,7 +29,7 @@ function MarkerIndex({
           direction: 'column',
           justify: 'center',
           align: 'center',
-          gap: 5,
+          gap: 6,
         }),
       ]}
     >

--- a/frontend/src/shared/components/markerIndex/markerIndex.stories.tsx
+++ b/frontend/src/shared/components/markerIndex/markerIndex.stories.tsx
@@ -11,12 +11,25 @@ const meta = {
   tags: ['autodocs'],
   argTypes: {
     index: {
-      control: { type: 'number', min: 1, max: 5 },
+      control: { type: 'number', min: 0, max: 10 },
       description: '마커에 표시될 인덱스 번호',
     },
+    type: {
+      control: { type: 'radio' },
+      options: ['recommended', 'starting'],
+      description: "'recommended' 또는 'starting' 타입",
+    },
+    label: {
+      control: 'text',
+      description: '하단에 표시할 라벨 텍스트',
+    },
     hasStroke: {
-      control: { type: 'boolean' },
-      description: '마커 stroke 여부',
+      control: 'boolean',
+      description: '마커에 테두리 추가 여부',
+    },
+    hasShadow: {
+      control: 'boolean',
+      description: '마커에 그림자 추가 여부',
     },
   },
 } satisfies Meta<typeof MarkerIndex>;
@@ -24,16 +37,46 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Case1_Recommended_All: Story = {
+  name: 'Case1 - 추천 장소, 라벨 + 스트로크 + 그림자',
   args: {
     index: 1,
-    hasStroke: false,
+    type: 'recommended',
+    label: '추천 장소',
+    hasStroke: true,
+    hasShadow: true,
   },
 };
 
-export const Stroke: Story = {
+export const Case2_Recommended_None: Story = {
+  name: 'Case2 - 추천 장소, 아무것도 없음',
   args: {
-    index: 1,
+    index: 2,
+    type: 'recommended',
+    label: '',
+    hasStroke: false,
+    hasShadow: false,
+  },
+};
+
+export const Case3_Starting_All: Story = {
+  name: 'Case3 - 출발지, 라벨 + 스트로크 + 그림자',
+  args: {
+    index: 3,
+    type: 'starting',
+    label: '출발역',
     hasStroke: true,
+    hasShadow: true,
+  },
+};
+
+export const Case4_Starting_StrokeShadow: Story = {
+  name: 'Case4 - 출발지, 스트로크 + 그림자',
+  args: {
+    index: 4,
+    type: 'starting',
+    label: '',
+    hasStroke: true,
+    hasShadow: true,
   },
 };

--- a/frontend/src/shared/components/markerIndex/markerIndex.stories.tsx
+++ b/frontend/src/shared/components/markerIndex/markerIndex.stories.tsx
@@ -11,7 +11,6 @@ const meta = {
   tags: ['autodocs'],
   argTypes: {
     index: {
-      control: { type: 'number', min: 0, max: 10 },
       description: '마커에 표시될 인덱스 번호',
     },
     type: {
@@ -62,7 +61,7 @@ export const Case2_Recommended_None: Story = {
 export const Case3_Starting_All: Story = {
   name: 'Case3 - 출발지, 라벨 + 스트로크 + 그림자',
   args: {
-    index: 3,
+    index: 'A',
     type: 'starting',
     label: '출발역',
     hasStroke: true,
@@ -73,7 +72,7 @@ export const Case3_Starting_All: Story = {
 export const Case4_Starting_StrokeShadow: Story = {
   name: 'Case4 - 출발지, 스트로크 + 그림자',
   args: {
-    index: 4,
+    index: 'B',
     type: 'starting',
     label: '',
     hasStroke: true,

--- a/frontend/src/shared/components/markerIndex/markerIndex.styled.ts
+++ b/frontend/src/shared/components/markerIndex/markerIndex.styled.ts
@@ -43,10 +43,10 @@ export const label_base = () => css`
   font-weight: 600;
   font-size: 10px;
   text-shadow:
-    -0.5px -0.5px 0 white,
-    0.5px -0.5px 0 white,
-    -0.5px 0.5px 0 white,
-    0.5px 0.5px 0 white;
+    -0.5px -0.5px 0 ${colorToken.gray[8]},
+    0.5px -0.5px 0 ${colorToken.gray[8]},
+    -0.5px 0.5px 0 ${colorToken.gray[8]},
+    0.5px 0.5px 0 ${colorToken.gray[8]};
 `;
 
 export const label_recommended = () => css`

--- a/frontend/src/shared/components/markerIndex/markerIndex.styled.ts
+++ b/frontend/src/shared/components/markerIndex/markerIndex.styled.ts
@@ -20,7 +20,7 @@ export const circle_base = () => css`
 `;
 
 export const circle_font = () => css`
-  transform: translate(5%, 5%);
+  transform: translate(0%, 5%);
 `;
 
 export const circle_recommended = () => css`

--- a/frontend/src/shared/components/markerIndex/markerIndex.styled.ts
+++ b/frontend/src/shared/components/markerIndex/markerIndex.styled.ts
@@ -42,6 +42,11 @@ export const circle_starting = () => css`
 export const label_base = () => css`
   font-weight: 600;
   font-size: 10px;
+  text-shadow:
+    -0.5px -0.5px 0 white,
+    0.5px -0.5px 0 white,
+    -0.5px 0.5px 0 white,
+    0.5px 0.5px 0 white;
 `;
 
 export const label_recommended = () => css`

--- a/frontend/src/shared/components/markerIndex/markerIndex.styled.ts
+++ b/frontend/src/shared/components/markerIndex/markerIndex.styled.ts
@@ -14,3 +14,40 @@ export const base = () => css`
 export const stroke = () => css`
   border: 4px solid ${colorToken.gray[8]};
 `;
+
+export const circle_base = () => css`
+  border-radius: ${borderRadiusToken.round};
+
+  span {
+    transform: translate(5%, 5%);
+  }
+`;
+
+export const circle_recommended = () => css`
+  width: 40px;
+  min-width: 40px;
+  height: 40px;
+  color: ${colorToken.gray[8]};
+  background-color: ${colorToken.main[1]};
+`;
+
+export const circle_starting = () => css`
+  width: 30px;
+  min-width: 30px;
+  height: 30px;
+  color: ${colorToken.gray[8]};
+  background-color: ${colorToken.orange[2]};
+`;
+
+export const label_base = () => css`
+  font-weight: 600;
+  font-size: 10px;
+`;
+
+export const label_recommended = () => css`
+  color: ${colorToken.gray[2]};
+`;
+
+export const label_starting = () => css`
+  color: ${colorToken.orange[1]};
+`;

--- a/frontend/src/shared/components/markerIndex/markerIndex.styled.ts
+++ b/frontend/src/shared/components/markerIndex/markerIndex.styled.ts
@@ -17,10 +17,10 @@ export const stroke = () => css`
 
 export const circle_base = () => css`
   border-radius: ${borderRadiusToken.round};
+`;
 
-  span {
-    transform: translate(5%, 5%);
-  }
+export const circle_font = () => css`
+  transform: translate(5%, 5%);
 `;
 
 export const circle_recommended = () => css`

--- a/frontend/src/shared/components/spotItem/SpotItem.tsx
+++ b/frontend/src/shared/components/spotItem/SpotItem.tsx
@@ -31,7 +31,7 @@ function SpotItem({
       ]}
       onClick={onClick}
     >
-      <MarkerIndex index={index} />
+      <MarkerIndex index={index} type="recommended" />
       <div
         css={[
           flex({ direction: 'column', gap: 10 }),


### PR DESCRIPTION
# #️⃣ Issue Number

#152 

## 🕹️ 작업 내용

[스토리북 배포](https://687b15d60d246cbdd1965dd5-nfnucfkkja.chromatic.com/?path=/docs/shared-markerindex--docs)

한 줄 요약 : 마커 인덱스 컴포넌트를 피그마 수정에 맞게 props 추가

[피그마 👇] 
<img width="493" height="137" alt="스크린샷 2025-08-07 오후 2 36 36" src="https://github.com/user-attachments/assets/5afdbae1-d910-4d6f-be8c-5c38d702411a" />

## 📋 리뷰 포인트

- [ ] 피그마 디자인과 동일하게 구현 되었나요?
- [ ] 마커 안에 글자(`index`)가 가운데 정렬인가요?

## 😀 질문

- 피그마에는 marker 와 하단 글씨 gap이 5로 잡혀있는데, 이를 구현할 때는 8로 바꾸는 건 어떤가요? 피그마는 글씨에 들어간 기본 높이가 있어서 5보다 더 넓어보여요. 
- 피그마에서 추천 마커랑 출발지 마커랑 gap이 달라요. 각 6랑 5입니다. 통일하면 좋을 것 같아요.

## 🔮 기타 사항

- 글자가 가운데 정렬되지 않는 이슈가 있었습니다. 폰트에 따른 이슈로 보입니다. `translate(5%, 5%)`으로 해결했습니다.
- [참고 문서](https://wit.nts-corp.com/2017/09/25/4903)

<img width="348" height="202" alt="스크린샷 2025-08-07 오후 2 39 46" src="https://github.com/user-attachments/assets/495eff62-9ee7-48fc-a66a-7423abc478ea" />
