### PR TITLE
[FE] test: 스토리북 파일에 title 속성 값에 자동으로 경로가 지정되도록 설정

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -14,7 +14,6 @@ module.exports = {
     { directory: '../src/features', titlePrefix: 'features', files: '**/*.stories.@(ts|tsx)'},
     { directory: '../src/entities', titlePrefix: 'entities', files: '**/*.stories.@(ts|tsx)' },
     { directory: '../src/widgets', titlePrefix: 'widgets', files: '**/*.stories.@(ts|tsx)' },
-    { directory: '../src/pages', titlePrefix: 'pages', files: '**/*.stories.@(ts|tsx)' },
     { directory: '../src/shared', titlePrefix: 'shared', files: '**/*.stories.@(ts|tsx)' },
   ],
 

--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -3,7 +3,20 @@ const path = require('path');
 
 /** @type {import('@storybook/react-webpack5').StorybookConfig} */
 module.exports = {
-  stories: ['../src/**/*.stories.@(ts|tsx)', '../src/**/*.mdx'],
+  /**
+   * stories 설정
+   * - directory: 스토리 파일이 있는 폴더 경로
+   * - titlePrefix: 자동 생성될 title의 상위 카테고리
+   * - files: 스토리 파일 패턴
+   * 이렇게 지정하면 title을 생략해도, 폴더 구조 기반으로 title이 자동 생성됨
+   */
+  stories: [
+    { directory: '../src/features', titlePrefix: 'features', files: '**/*.stories.@(ts|tsx)'},
+    { directory: '../src/entities', titlePrefix: 'entities', files: '**/*.stories.@(ts|tsx)' },
+    { directory: '../src/widgets', titlePrefix: 'widgets', files: '**/*.stories.@(ts|tsx)' },
+    { directory: '../src/pages', titlePrefix: 'pages', files: '**/*.stories.@(ts|tsx)' },
+    { directory: '../src/shared', titlePrefix: 'shared', files: '**/*.stories.@(ts|tsx)' },
+  ],
 
   addons: [
     getAbsolutePath('@storybook/addon-docs'),
@@ -16,6 +29,7 @@ module.exports = {
   },
 
   webpackFinal: async (config) => {
+    // Emotion + TypeScript + React를 위한 Babel 로더 추가
     config.module?.rules?.push({
       test: /\.(ts|tsx)$/,
       exclude: /node_modules/,
@@ -38,8 +52,10 @@ module.exports = {
       },
     });
 
+    // .ts, .tsx 확장자 지원 추가
     config.resolve?.extensions?.push('.ts', '.tsx');
 
+    // 절대 경로 alias 설정
     if (config.resolve) {
       config.resolve.alias = {
         ...config.resolve.alias,
@@ -49,10 +65,7 @@ module.exports = {
         '@features': path.resolve(__dirname, '../src/features'),
         '@entities': path.resolve(__dirname, '../src/entities'),
         '@shared': path.resolve(__dirname, '../src/shared'),
-        '@shared/components': path.resolve(
-          __dirname,
-          '../src/shared/components',
-        ),
+        '@shared/components': path.resolve(__dirname, '../src/shared/components'),
         '@shared/styles': path.resolve(__dirname, '../src/shared/styles'),
         '@shared/types': path.resolve(__dirname, '../src/shared/types'),
         '@icons': path.resolve(__dirname, '../assets/icon'),
@@ -66,9 +79,8 @@ module.exports = {
 };
 
 /**
- * 주어진 패키지 이름의 package.json 절대 경로를 기반으로 루트 디렉토리 경로 반환
- * @param {string} pkg 패키지 이름 (e.g. '@storybook/addon-docs')
- * @returns {string} 절대 경로
+ * 지정한 패키지 이름의 루트 디렉토리 경로 반환
+ * Storybook addon 경로를 절대경로로 변환할 때 사용
  */
 function getAbsolutePath(pkg) {
   return path.dirname(require.resolve(path.join(pkg, 'package.json')));

--- a/frontend/src/features/meeting/components/conditionCard/conditionCard.stories.ts
+++ b/frontend/src/features/meeting/components/conditionCard/conditionCard.stories.ts
@@ -3,7 +3,6 @@ import ConditionCard from './ConditionCard';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'features/meeting/ConditionCard',
   component: ConditionCard,
   parameters: {
     layout: 'centered',

--- a/frontend/src/features/meeting/components/conditionSelector/conditionSelector.stories.ts
+++ b/frontend/src/features/meeting/components/conditionSelector/conditionSelector.stories.ts
@@ -3,7 +3,6 @@ import ConditionSelector from './ConditionSelector';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'features/meeting/ConditionSelector',
   component: ConditionSelector,
   parameters: {
     layout: 'centered',

--- a/frontend/src/features/meeting/components/departureInput/departureInput.stories.ts
+++ b/frontend/src/features/meeting/components/departureInput/departureInput.stories.ts
@@ -3,7 +3,6 @@ import DepartureInput from './DepartureInput';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'features/meeting/DepartureInput',
   component: DepartureInput,
   parameters: {
     layout: 'centered',

--- a/frontend/src/features/recommendation/components/bottomSheet/bottomSheet.stories.ts
+++ b/frontend/src/features/recommendation/components/bottomSheet/bottomSheet.stories.ts
@@ -10,7 +10,6 @@ import BottomSheet from './BottomSheet';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'features/BottomSheet',
   component: BottomSheet,
   decorators: [withContainer],
   parameters: {

--- a/frontend/src/features/recommendation/components/spotItemList/spotItemList.stories.ts
+++ b/frontend/src/features/recommendation/components/spotItemList/spotItemList.stories.ts
@@ -7,7 +7,6 @@ import SpotItemList from './SpotItemList';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'features/SpotItemList',
   component: SpotItemList,
   decorators: [withContainer],
   parameters: {

--- a/frontend/src/pages/pages.stories.tsx
+++ b/frontend/src/pages/pages.stories.tsx
@@ -4,7 +4,6 @@ import App from '../app/App';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta: Meta<typeof App> = {
-  title: 'Pages',
   component: App,
   decorators: [withLayout],
   parameters: {

--- a/frontend/src/shared/components/badge/badge.stories.ts
+++ b/frontend/src/shared/components/badge/badge.stories.ts
@@ -3,7 +3,6 @@ import Badge from './Badge';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'shared/Badge',
   component: Badge,
   parameters: {
     layout: 'centered',

--- a/frontend/src/shared/components/bottomButton/bottomButton.stories.ts
+++ b/frontend/src/shared/components/bottomButton/bottomButton.stories.ts
@@ -3,7 +3,6 @@ import BottomButton from './BottomButton';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'shared/BottomButton',
   component: BottomButton,
   parameters: {
     layout: 'centered',

--- a/frontend/src/shared/components/headerLogo/headerLogo.stories.ts
+++ b/frontend/src/shared/components/headerLogo/headerLogo.stories.ts
@@ -3,7 +3,6 @@ import HeaderLogo from './HeaderLogo';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'shared/Logo/HeaderLogo',
   component: HeaderLogo,
   parameters: {
     layout: 'centered',

--- a/frontend/src/shared/components/input/input.stories.ts
+++ b/frontend/src/shared/components/input/input.stories.ts
@@ -3,7 +3,6 @@ import Input from './Input';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'shared/Input',
   component: Input,
   parameters: {
     layout: 'centered',

--- a/frontend/src/shared/components/logo/logo.stories.ts
+++ b/frontend/src/shared/components/logo/logo.stories.ts
@@ -3,7 +3,6 @@ import Logo from './Logo';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'shared/Logo/Logo',
   component: Logo,
   parameters: {
     layout: 'centered',

--- a/frontend/src/shared/components/mapButton/mapButton.stories.ts
+++ b/frontend/src/shared/components/mapButton/mapButton.stories.ts
@@ -6,7 +6,6 @@ import MapButton from './MapButton';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'shared/MapButton',
   component: MapButton,
   parameters: {
     layout: 'centered',

--- a/frontend/src/shared/components/mapPoint/mapPoint.stories.ts
+++ b/frontend/src/shared/components/mapPoint/mapPoint.stories.ts
@@ -3,7 +3,6 @@ import MapPoint from './MapPoint';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'shared/MapPoint',
   component: MapPoint,
   parameters: {
     layout: 'centered',

--- a/frontend/src/shared/components/markerIndex/markerIndex.stories.tsx
+++ b/frontend/src/shared/components/markerIndex/markerIndex.stories.tsx
@@ -3,7 +3,6 @@ import MarkerIndex from './MarkerIndex';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'shared/MarkerIndex',
   component: MarkerIndex,
   parameters: {
     layout: 'centered',

--- a/frontend/src/shared/components/spotItem/spotItem.stories.ts
+++ b/frontend/src/shared/components/spotItem/spotItem.stories.ts
@@ -5,7 +5,6 @@ import SpotItem from './SpotItem';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'shared/SpotItem',
   component: SpotItem,
   decorators: [withContainer],
   parameters: {

--- a/frontend/src/shared/components/startingSpotName/startingSpotName.stories.ts
+++ b/frontend/src/shared/components/startingSpotName/startingSpotName.stories.ts
@@ -5,7 +5,6 @@ import StartingSpotName from './StartingSpotName';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'shared/StartingSpotName',
   component: StartingSpotName,
   parameters: {
     layout: 'centered',

--- a/frontend/src/shared/components/startingSpotWrapper/startingSpotWrapper.stories.ts
+++ b/frontend/src/shared/components/startingSpotWrapper/startingSpotWrapper.stories.ts
@@ -7,7 +7,6 @@ import StartingSpotWrapper from './StartingSpotWrapper';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'shared/StartingSpotWrapper',
   component: StartingSpotWrapper,
   decorators: [withContainer],
   parameters: {

--- a/frontend/src/shared/components/tag/tag.stories.ts
+++ b/frontend/src/shared/components/tag/tag.stories.ts
@@ -3,7 +3,6 @@ import Tag from './Tag';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'shared/Tag',
   component: Tag,
   parameters: {
     layout: 'centered',

--- a/frontend/src/shared/components/textarea/textarea.stories.ts
+++ b/frontend/src/shared/components/textarea/textarea.stories.ts
@@ -3,7 +3,6 @@ import Textarea from './Textarea';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'shared/Textarea',
   component: Textarea,
   parameters: {
     layout: 'centered',


### PR DESCRIPTION
# #️⃣ Issue Number

## 🕹️ 작업 내용

한 줄 요약 : 스토리북 파일에 title 속성 값에 자동으로 경로가 지정되도록 설정

[스토리북 배포](https://687b15d60d246cbdd1965dd5-aqlbkyrgfb.chromatic.com/)

- 경로가 `features/도메인/components/컴포넌트_폴터/컴포넌트_파일.tsx`이라면,
- 스토리북 title이 `features/도메인/components/컴포넌트_파일.tsx`로 설정됨. 


## 📋 리뷰 포인트

- [ ] 스토리북 파일에 title을 작성하지 않아도 자동 설정되나요?
- [ ] 스토리북이 정상적으로 실행되나요?
- [ ] 스토리북이 정상적으로 배포되나요?

## 🔮 기타 사항

- title을 도메인 하위로 옮기려던 수작업을 대신해, 자동화를 위해 설정 파일을 수정했습니다.
- 스토리북 title 경로에서 `components`를 빼는 게 좋을까요?
