### PR TITLE
[FE] feat: 브라우저에 따른 스크롤 사이즈 조정

### DIFF
--- a/frontend/src/pages/indexPage/indexPage.styled.ts
+++ b/frontend/src/pages/indexPage/indexPage.styled.ts
@@ -4,7 +4,7 @@ import { colorToken } from '@shared/styles/tokens';
 
 export const container = () => css`
   width: 100%;
-  height: 100vh;
+  height: 100dvh;
   background-color: ${colorToken.bg[1]};
   padding-bottom: 30px;
 `;

--- a/frontend/src/shared/components/layout/layout.styled.ts
+++ b/frontend/src/shared/components/layout/layout.styled.ts
@@ -5,13 +5,13 @@ import { colorToken } from '@shared/styles/tokens';
 export const container = () => css`
   display: flex;
   width: 100%;
-  min-height: 100vh;
+  min-height: 100dvh;
   background-color: ${colorToken.main[4]};
 `;
 
 export const content = () => css`
   width: 100%;
-  min-height: 100vh;
+  min-height: 100dvh;
   background-color: ${colorToken.gray[8]};
 
   @media (min-width: 400px) {

--- a/frontend/src/shared/components/layout/layout.styled.ts
+++ b/frontend/src/shared/components/layout/layout.styled.ts
@@ -12,6 +12,7 @@ export const container = () => css`
 export const content = () => css`
   width: 100%;
   min-height: 100dvh;
+  overflow-x: hidden;
   background-color: ${colorToken.gray[8]};
 
   @media (min-width: 400px) {

--- a/frontend/src/shared/components/layout/layout.styled.ts
+++ b/frontend/src/shared/components/layout/layout.styled.ts
@@ -12,7 +12,6 @@ export const container = () => css`
 export const content = () => css`
   width: 100%;
   min-height: 100vh;
-  overflow-y: auto;
   background-color: ${colorToken.gray[8]};
 
   @media (min-width: 400px) {


### PR DESCRIPTION
# #️⃣ Issue Number
#212 

## 🕹️ 작업 내용

한 줄 요약 : 모바일뷰에서 브라우저에 따른 스크롤 사이즈를 조정하였습니다.

- [x] 사파리
- [x] 크롬

## 📋 리뷰 포인트

- [ ] 사파리, 크롬의 각 모바일 / 데스크탑 뷰에서 정상적으로 동작하는지 확인해주세요
  - [ ] 데스크탑의 환경에서 resultPage > detail 일때, 가로길이가 깨지지 않고 보이는지 확인해주세요.
  - [ ] indexPage에서 스크롤이 씹히지 않고 정상적으로 동작하는지 확인해주세요
    - before
        ![Simulator Screen Recording - iPhone 16 - 2025-08-16 at 22 10 47](https://github.com/user-attachments/assets/8b799f13-64b4-4fb8-8050-5129035a2535)

  - [ ] resultPage에서 bottomSheet와 페이지 전체 모두 스크롤되지 않고 bottomSheet만 스크롤되는지 확인해주세요.
    - before
        ![Simulator Screen Recording - iPhone 16 - 2025-08-16 at 22 26 12](https://github.com/user-attachments/assets/764c5a86-a1f5-48e3-98ce-3dbd2df17eda)
    - after
        ![Simulator Screen Recording - iPhone 16 - 2025-08-17 at 00 29 43](https://github.com/user-attachments/assets/a38a7fcc-4b0f-4155-9d05-1b220d997a1d)
    


## 🔮 기타 사항

- 기존의 `height` 의 단위를 `vh`를 사용하여서 생기는 문제점을 `dvh`로 해결했습니다.
  - `vh` :  브라우저의 주소창이나 하단 네비게이션 바와 같은 동적 UI 요소를 고려하지 않고 viewport 높이를 계산합니다. 모바일에서 주소창이 나타나거나 사라질 때 레이아웃이 깨지거나 콘텐츠가 잘리는 문제가 발생할 수 있습니다.
  - `dvh` : 이러한 동적 UI 요소들의 상태 변화를 실시간으로 감지하여 viewport 높이를 자동으로 조정합니다. 동적으로 변하는 viewport 높이에 맞춰 자동으로 조정되어 더 자연스러운 UX를 제공합니다.
  - 이러한 이유로 layout.styled.ts에서 vh를 dvh로 변경함으로써, 모바일 환경에서 더 안정적이고 일관된 레이아웃을 제공할 수 있게 되었습니다.
- `layout.styled.ts`의 `content` 컴포넌트에서 `overflow-y: auto`를 제거하면 detail 뷰에서 내부 컨텐츠의 가로 오버플로우가 제한되지 않아 400px 고정 너비를 벗어나는 레이아웃 이슈가 발생하므로, `overflow-x: hidden` 속성을 추가했어요.
