### PR TITLE
[FE] refactor: 신분당선으로 네이밍 수정

### DIFF
--- a/frontend/src/entities/types/LineCode.ts
+++ b/frontend/src/entities/types/LineCode.ts
@@ -18,7 +18,7 @@ export const SUBWAY_LINE_INFO: { [key: string]: SubwayLineInfo } = {
   GYEONGUI_JOUNGANG: { name: '경의중앙선', code: 104 },
   EVERLINE: { name: '용인 에버라인', code: 107 },
   GYEONGCHUN: { name: '경춘선', code: 108 },
-  SIN_BUNDANG: { name: '신분당', code: 109 },
+  SIN_BUNDANG: { name: '신분당선', code: 109 },
   UIJEONGBU_LRT: { name: '의정부 경전철', code: 110 },
   GYEONGGANG: { name: '경강선', code: 112 },
   WOOE_SINSEUL_LRT: { name: '우이 신설선', code: 113 },

--- a/frontend/src/features/map/components/map/Map.tsx
+++ b/frontend/src/features/map/components/map/Map.tsx
@@ -49,7 +49,7 @@ function Map({
         )}
       </div>
       <div css={[flex({ justify: 'space-between' }), map.bottom_overlay()]}>
-        <MapPoint text="전체 추첨 지점" />
+        <MapPoint text="전체 추천 지점" />
       </div>
     </div>
   );

--- a/frontend/src/mocks/routeCardMock.ts
+++ b/frontend/src/mocks/routeCardMock.ts
@@ -65,7 +65,7 @@ export const routeCardMock: RecommendedRoute = {
       endStation: '강남',
       endingX: 127.028351,
       endingY: 37.49637,
-      lineCode: '신분당',
+      lineCode: '신분당선',
       travelTime: 7,
     },
   ],

--- a/frontend/src/shared/styles/tokens.css
+++ b/frontend/src/shared/styles/tokens.css
@@ -42,7 +42,7 @@
   --color-subway-line-104: #77c4a3; /* 경의중앙선 */
   --color-subway-line-107: #6fb245; /* 용인 에버라인 */
   --color-subway-line-108: #0c8e72; /* 경춘선 */
-  --color-subway-line-109: #d31145; /* 신분당선선 */
+  --color-subway-line-109: #d31145; /* 신분당선 */
   --color-subway-line-110: #f5a200; /* 의정부 경전철 */
   --color-subway-line-112: #0054a6; /* 경강선 */
   --color-subway-line-113: #b7c452; /* 우이 신설선 */

--- a/frontend/src/shared/styles/tokens.css
+++ b/frontend/src/shared/styles/tokens.css
@@ -42,7 +42,7 @@
   --color-subway-line-104: #77c4a3; /* 경의중앙선 */
   --color-subway-line-107: #6fb245; /* 용인 에버라인 */
   --color-subway-line-108: #0c8e72; /* 경춘선 */
-  --color-subway-line-109: #d31145; /* 신분당선 */
+  --color-subway-line-109: #d31145; /* 신분당선선 */
   --color-subway-line-110: #f5a200; /* 의정부 경전철 */
   --color-subway-line-112: #0054a6; /* 경강선 */
   --color-subway-line-113: #b7c452; /* 우이 신설선 */


### PR DESCRIPTION
# #️⃣ Issue Number
#234 
## 🕹️ 작업 내용

한 줄 요약 : 지하철 호선명 '신분당'을 '신분당선'으로 수정했어요.

지하철 호선명 변경이 반영된 파일은 아래와 같아요. 이 외에서는 지하철 호선명이 사용되지 않아요.
- [x] LineCode (지하철 name 과 code명을 지정한 타입)
- [x] routeCardMock (목데이터)
- [x] tokens.css (토큰)

## 📋 리뷰 포인트

- api 응답이 신분당선으로 오는 경우, 올바르게 받고 있는지 확인해주세요.
