### PR TITLE
[FE] style: BottomSheet 내부 글자 잘림 해결과 줄 간격 수정

### DIFF
--- a/frontend/src/features/recommendation/components/bottomSheetDetail/bottomSheetDetail.styled.ts
+++ b/frontend/src/features/recommendation/components/bottomSheetDetail/bottomSheetDetail.styled.ts
@@ -15,6 +15,7 @@ export const reason = () => css`
 
 export const reasonText = () => css`
   color: ${colorToken.gray[2]};
+  line-height: 1.5;
 `;
 
 export const placeList = () => css`

--- a/frontend/src/shared/components/spotItem/spotItem.styled.ts
+++ b/frontend/src/shared/components/spotItem/spotItem.styled.ts
@@ -16,8 +16,8 @@ export const base = () => css`
 `;
 
 export const contents_container = () => css`
-  overflow: hidden;
   width: 100%;
+  overflow: hidden;
   padding-top: 1px;
 `;
 

--- a/frontend/src/shared/components/spotItem/spotItem.styled.ts
+++ b/frontend/src/shared/components/spotItem/spotItem.styled.ts
@@ -16,12 +16,14 @@ export const base = () => css`
 `;
 
 export const contents_container = () => css`
+  overflow: hidden;
   width: 100%;
+  padding-top: 1px;
 `;
 
 export const description = () => css`
-  display: -webkit-box;
-  -webkit-line-clamp: 1;
-  -webkit-box-orient: vertical;
   overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding-top: 1px;
 `;


### PR DESCRIPTION
# #️⃣ Issue Number

#237 

## 🕹️ 작업 내용

한 줄 요약 :

- BottomSheet 내부 글자 잘림 이슈 해결
- BottomSheetDetail의 설명란 내부 text에 줄 간격 확대

### 1) BottomSheet 내부 글자 잘림 이슈 해결(BEFORE & AFTER)

<img width="353" height="54" alt="Image" src="https://github.com/user-attachments/assets/3cb77a23-b5c6-4155-8337-38d9b81d3320" />

<img width="347" height="49" alt="스크린샷 2025-08-20 오전 6 42 15" src="https://github.com/user-attachments/assets/cb0064c8-db2f-4a9b-beba-117da0ec6fa1" />

###  2) BottomSheetDetail의 설명란 내부 text에 줄 간격 확대(BEFORE & AFTER)

<img width="380" height="111" alt="스크린샷 2025-08-20 오전 6 41 56" src="https://github.com/user-attachments/assets/3442172d-3114-40e2-a8d4-43ac4e4938a6" />

<img width="377" height="133" alt="스크린샷 2025-08-20 오전 6 41 39" src="https://github.com/user-attachments/assets/836d7a97-8b67-4d5a-b197-efd537d4c888" />

## 📋 리뷰 포인트

- [ ] 이슈가 정상적으로 해결됐나요?
- [ ] `BottomSheetDetail의 설명란 내부` 줄 간격은 line-height 1.5로 잡았는데 적절한가요? (1.5는 좀 간격이 넓은 것 같기도 하고, 값이 고민이 됐어요)
