### PR TITLE
[FE] fix: localStorage에 빈 값이 일 때 JSON.parse 실패 버그 해결

### DIFF
--- a/frontend/src/entities/model/meetingStorage.ts
+++ b/frontend/src/entities/model/meetingStorage.ts
@@ -20,12 +20,12 @@ export function setMeetingStorage(params: {
 export function getMeetingStorage(): {
   departureList: string[];
   conditionID: LocationRequirement;
-  } {
+} {
   const departureList = JSON.parse(
     localStorage.getItem(MEETING_DEPARTURE_LIST) ?? '[]',
   );
   const conditionID = JSON.parse(
-    localStorage.getItem(MEETING_CONDITION_ID) ?? '',
+    localStorage.getItem(MEETING_CONDITION_ID) ?? 'null',
   );
 
   return { departureList, conditionID };

--- a/frontend/src/entities/model/meetingStorage.ts
+++ b/frontend/src/entities/model/meetingStorage.ts
@@ -20,7 +20,7 @@ export function setMeetingStorage(params: {
 export function getMeetingStorage(): {
   departureList: string[];
   conditionID: LocationRequirement;
-} {
+  } {
   const departureList = JSON.parse(
     localStorage.getItem(MEETING_DEPARTURE_LIST) ?? '[]',
   );


### PR DESCRIPTION
# #️⃣ Issue Number

## 🕹️ 작업 내용

#251 

한 줄 요약 : localStorage에 MEETING_CONDITION_ID를 키로 값을 가져왔을 때, 빈 값이면 null 값으로 처리한다.

기존에 빈 값이면, null이 아니라 ''로 처리했었는데 빈 문자열은 JSON.parse가 처리할 수 없어서 오류가 났습니다. 

## 📋 리뷰 포인트

-
-

## 🔮 기타 사항

-
-
