### PR TITLE
fix: RouteCardDetail 컴포넌트의 key 경고 해결

### DIFF
--- a/frontend/src/features/recommendation/components/routeCardDetail/RouteCardDetail.tsx
+++ b/frontend/src/features/recommendation/components/routeCardDetail/RouteCardDetail.tsx
@@ -12,20 +12,18 @@ interface RouteCardDetailProps {
 function RouteCardDetail({ paths }: RouteCardDetailProps) {
   return (
     <div css={flex({ direction: 'column', gap: 2 })}>
-      {paths.map((path) => (
-        <>
-          {path.startStation !== path.endStation ? (
-            <RouteSegment
-              key={path.index}
-              lineCode={path.lineCode}
-              startStation={path.startStation}
-              endStation={path.endStation}
-            />
-          ) : (
-            <RouteIndicator />
-          )}
-        </>
-      ))}
+      {paths.map((path) =>
+        path.startStation !== path.endStation ? (
+          <RouteSegment
+            key={path.index}
+            lineCode={path.lineCode}
+            startStation={path.startStation}
+            endStation={path.endStation}
+          />
+        ) : (
+          <RouteIndicator key={path.index} />
+        ),
+      )}
     </div>
   );
 }


### PR DESCRIPTION
# #️⃣ Issue Number
#258 

## 🕹️ 작업 내용

한 줄 요약 : RouteCardDetail 컴포넌트의 key 경고 해결

- [x] 불필요한 Fragment 제거
- [x] 조건부 렌더링되는 컴포넌트에 직접 key prop 적용
- [x] 코드 구조 개선 및 간소화

## 📋 리뷰 포인트

- [x] detail 페이지에서 발생하던 RouteCardDetail컴포넌트의 key 경고가 해결되었는지 확인해주세요.

## 🔮 기타 사항

-
-
