### PR TITLE
[FE] feat: 지도 위 모든 마커들의 좌표를 바탕으로 중앙 좌표를 계산하여, 이를 지도의 중심 좌표로 사용

### DIFF
--- a/frontend/src/features/map/hooks/useCustomOverlays.tsx
+++ b/frontend/src/features/map/hooks/useCustomOverlays.tsx
@@ -9,6 +9,7 @@ import MarkerIndex from '@shared/components/markerIndex/MarkerIndex';
 import { numberToCharCode } from '@shared/utils/numberToCharCode';
 
 import { CustomOverlay } from '../lib/CustomOverlay';
+import { getCenterFromCoords } from '../lib/getCenterFromCoords';
 
 interface useCustomOverlaysProps {
   startingLocations: StartingPlace[];
@@ -31,7 +32,13 @@ export const useCustomOverlays = ({
 
     if (allLocations.length === 0) return;
 
-    const center = new naver.maps.LatLng(allLocations[0].y, allLocations[0].x);
+    const { centerCoord } = getCenterFromCoords(
+      allLocations.map((location) => ({
+        x: location.x,
+        y: location.y,
+      })),
+    );
+    const center = new naver.maps.LatLng(centerCoord.y - 0.1, centerCoord.x);
 
     const naverMap = new naver.maps.Map(mapRef.current, {
       center,

--- a/frontend/src/features/map/lib/getCenterFromCoords.ts
+++ b/frontend/src/features/map/lib/getCenterFromCoords.ts
@@ -1,0 +1,27 @@
+export type Coord = { x: number; y: number };
+
+export function getCenterFromCoords(coords: Coord[]) {
+  if (coords.length === 0) {
+    throw new Error('coords 배열이 비어 있습니다.');
+  }
+
+  let minY = coords[0].y;
+  let maxY = coords[0].y;
+  let minX = coords[0].x;
+  let maxX = coords[0].x;
+
+  for (let i = 1; i < coords.length; i++) {
+    const { x, y } = coords[i];
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+  }
+
+  const centerY = (minY + maxY) / 2;
+  const centerX = (minX + maxX) / 2;
+
+  return {
+    centerCoord: { x: centerX, y: centerY },
+  };
+}


### PR DESCRIPTION
# #️⃣ Issue Number

#268 

## 🕹️ 작업 내용

한 줄 요약 : 지도 위 모든 마커들의 좌표를 바탕으로 중앙 좌표를 계산하여, 이를 지도의 중심 좌표로 사용

- 목적
  - 기본 바텀시트 높이 위로 마커가 잘 보이도록 한다.
  - 가능한 모든 마커가 지도 뷰포트 안에 들어오도록 한다.

- BEFORE: 첫 번째 마커의 좌표를 중심으로 사용 
<img width="364" height="340" alt="스크린샷 2025-08-21 오후 2 14 12" src="https://github.com/user-attachments/assets/d7e192e6-5eca-4805-941c-08fa3d133e01" />

- AFTER: 모든 마커의 좌표를 계산하여 중심 좌표를 중앙으로 사용
<img width="409" height="421" alt="스크린샷 2025-08-21 오후 2 13 42" src="https://github.com/user-attachments/assets/73b73a80-37f2-4aea-8db1-c47c75ebb546" />


- [ ] 중심 좌표 계산 로직 구현
- [ ] 중심 좌표를 지도의 중앙으로 사용
- [ ] 기본 바텀시트 높이 위로 좌표가 보이도록 하기 위해서 y 좌표에 0.1 좌표를 뺌

## 📋 리뷰 포인트

- 기본 바텀시트 높이 위로 마커가 잘 보이나요?
- 가능한 모든 마커가 지도 뷰포트 안에 들어오나요?
