### PR TITLE
[BE] fix: 잘못 설정된 모니터링 지표 namespace 수정

### DIFF
--- a/backend/src/main/java/com/f12/moitz/common/config/MonitoringConfig.java
+++ b/backend/src/main/java/com/f12/moitz/common/config/MonitoringConfig.java
@@ -4,10 +4,10 @@ import io.micrometer.cloudwatch2.CloudWatchConfig;
 import io.micrometer.cloudwatch2.CloudWatchMeterRegistry;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.config.MeterFilter;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.time.Duration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
 
@@ -15,7 +15,7 @@ import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
 public class MonitoringConfig {
 
     @Bean
-    public CloudWatchConfig cloudWatchConfig() {
+    public CloudWatchConfig cloudWatchConfig(@Value("${monitoring.namespace}") final String namespace) {
         return new CloudWatchConfig() {
             @Override
             public String get(String key) {
@@ -24,7 +24,7 @@ public class MonitoringConfig {
 
             @Override
             public String namespace() {
-                return "Moitz2025Dev";
+                return namespace;
             }
 
             @Override

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -1,1 +1,2 @@
 spring.data.mongodb.host=10.0.0.68
+monitoring.namespace=Moitz2025Dev

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -1,1 +1,2 @@
 spring.data.mongodb.host=10.0.100.220
+monitoring.namespace=Moitz2025Prod


### PR DESCRIPTION
# #️⃣ Issue Number
#319 

## 🕹️ 작업 내용

한 줄 요약 : `MonitoringConfig`에서 지정하는 메트릭 namespace도 환경에 따라 분리하였습니다

- [x] 개발 환경 namespace 별도 적용
- [x] 운영 환경 namespace 별도 적용

## 📋 리뷰 포인트

- `@Value` 애노테이션 사용이나 namespace명 세팅에 실수가 없는지?

## 🔮 기타 사항

- main까지 재배포되어야 운영 환경 메트릭이 제대로 수집되는지 확인 가능합니다
- import문이 알파벳 내림차 순으로 재정렬되었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced environment-specific monitoring namespaces to better separate metrics across dev and prod.
  * Standardized metrics reporting interval to 1 minute for more timely visibility.
  * Updated configuration to inject the monitoring namespace from environment properties.
  * Added dedicated namespace values for development and production environments.
  * Improves observability and operational insight without affecting end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->