### PR TITLE
[FE] refactor: Progressbar 모션이 끝난 후 리다이렉트 되도록 수정

### DIFF
--- a/frontend/src/entities/location/hooks/useLocations.test.tsx
+++ b/frontend/src/entities/location/hooks/useLocations.test.tsx
@@ -63,17 +63,19 @@ describe('useLocations', () => {
       );
 
       // then: 초기에는 로딩 중이어야 한다
+      let data;
       await act(async () => {
-        await result.current.getRecommendationResult(id);
+        data = await result.current.getRecommendationResult(id);
       });
 
       // then: 데이터가 정상적으로 로드되어야 한다
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
         expect(result.current.isError).toBe(false);
-        expect(result.current.data.recommendedLocations.length).toBeGreaterThan(
-          0,
-        );
+
+        // 반환된 데이터 검증
+        expect(data).toBeDefined();
+        expect(data.recommendedLocations.length).toBeGreaterThan(0);
       });
     });
 

--- a/frontend/src/entities/location/hooks/useLocations.ts
+++ b/frontend/src/entities/location/hooks/useLocations.ts
@@ -7,23 +7,24 @@ import { Location } from '@entities/location/types/Location';
 
 export type useLocationsReturn = {
   data: Location;
+  isProgressLoading: boolean;
   isLoading: boolean;
   isError: boolean;
   errorMessage: string;
-  getRecommendationId: (
-    requestBody: RecommendationRequestBody,
-  ) => Promise<string>;
-  getRecommendationResult: (id: string) => Promise<void>;
+  getRecommendationId: (requestBody: RecommendationRequestBody) => Promise<string>;
+  getRecommendationResult: (id: string) => Promise<Location>;
+  getRecommendation: (requestBody: RecommendationRequestBody) => Promise<{ id: string; data: Location }>;
 };
 
 const initialData: Location = {
   startingPlaces: [],
-  recommendedLocations: [],
+  recommendedLocations: []
 };
 
 const useLocations = (): useLocationsReturn => {
   const [data, setData] = useState<Location>(initialData);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isProgressLoading, setIsProgressLoading] = useState(false); // ProgressLoading 컴포넌트 렌더링 여부
+  const [isLoading, setIsLoading] = useState(false); // 데이터 fetch에 따른 로딩 여부
   const [isError, setIsError] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
 
@@ -33,28 +34,8 @@ const useLocations = (): useLocationsReturn => {
       setIsError(false);
       setErrorMessage('');
 
-      try {
-        const id = await fetchRecommendationId(requestBody);
-        return id;
-      } catch (error) {
-        setIsError(true);
-        setErrorMessage(error instanceof Error ? error.message : String(error));
-        throw error;
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [],
-  );
-
-  const getRecommendationResult = useCallback(async (id: string) => {
-    setIsLoading(true);
-    setIsError(false);
-    setErrorMessage('');
-
     try {
-      const locations = await fetchRecommendationResult(id);
-      setData(locations);
+      return await fetchRecommendationId(requestBody);
     } catch (error) {
       setIsError(true);
       setErrorMessage(error instanceof Error ? error.message : String(error));
@@ -64,13 +45,52 @@ const useLocations = (): useLocationsReturn => {
     }
   }, []);
 
+  const getRecommendationResult = useCallback(async (id: string) => {
+    setIsLoading(true);
+    setIsError(false);
+    setErrorMessage('');
+
+    try {
+      const locations = await fetchRecommendationResult(id);
+      setData(locations);
+      return locations;
+    } catch (error) {
+      setIsError(true);
+      setErrorMessage(error instanceof Error ? error.message : String(error));
+      throw error;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const getRecommendation = useCallback(async (requestBody: RecommendationRequestBody) => {
+    setIsProgressLoading(true);
+    setData(initialData);
+    try {
+      const newId = await getRecommendationId(requestBody);
+      const newData = await getRecommendationResult(newId);
+
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      return { id: newId, data: newData };
+    } catch (error) {
+      setIsError(true);
+      setErrorMessage(error instanceof Error ? error.message : String(error));
+      throw error;
+    } finally {
+      setIsProgressLoading(false);
+    }
+  }, []);
+
   return {
     data,
+    isProgressLoading,
     isLoading,
     isError,
     errorMessage,
     getRecommendationId,
     getRecommendationResult,
+    getRecommendation
   };
 };
 

--- a/frontend/src/entities/location/hooks/useLocations.ts
+++ b/frontend/src/entities/location/hooks/useLocations.ts
@@ -15,7 +15,7 @@ export type useLocationsReturn = {
     requestBody: RecommendationRequestBody,
   ) => Promise<string>;
   getRecommendationResult: (id: string) => Promise<Location>;
-  getRecommendation: (
+  getRecommendationFull: (
     requestBody: RecommendationRequestBody,
   ) => Promise<{ id: string; data: Location }>;
 };
@@ -69,7 +69,7 @@ const useLocations = (): useLocationsReturn => {
     }
   }, []);
 
-  const getRecommendation = useCallback(
+  const getRecommendationFull = useCallback(
     async (requestBody: RecommendationRequestBody) => {
       setIsProgressLoading(true);
       setData(initialData);
@@ -99,7 +99,7 @@ const useLocations = (): useLocationsReturn => {
     errorMessage,
     getRecommendationId,
     getRecommendationResult,
-    getRecommendation,
+    getRecommendationFull,
   };
 };
 

--- a/frontend/src/entities/location/hooks/useLocations.ts
+++ b/frontend/src/entities/location/hooks/useLocations.ts
@@ -11,14 +11,18 @@ export type useLocationsReturn = {
   isLoading: boolean;
   isError: boolean;
   errorMessage: string;
-  getRecommendationId: (requestBody: RecommendationRequestBody) => Promise<string>;
+  getRecommendationId: (
+    requestBody: RecommendationRequestBody,
+  ) => Promise<string>;
   getRecommendationResult: (id: string) => Promise<Location>;
-  getRecommendation: (requestBody: RecommendationRequestBody) => Promise<{ id: string; data: Location }>;
+  getRecommendation: (
+    requestBody: RecommendationRequestBody,
+  ) => Promise<{ id: string; data: Location }>;
 };
 
 const initialData: Location = {
   startingPlaces: [],
-  recommendedLocations: []
+  recommendedLocations: [],
 };
 
 const useLocations = (): useLocationsReturn => {
@@ -34,16 +38,18 @@ const useLocations = (): useLocationsReturn => {
       setIsError(false);
       setErrorMessage('');
 
-    try {
-      return await fetchRecommendationId(requestBody);
-    } catch (error) {
-      setIsError(true);
-      setErrorMessage(error instanceof Error ? error.message : String(error));
-      throw error;
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+      try {
+        return await fetchRecommendationId(requestBody);
+      } catch (error) {
+        setIsError(true);
+        setErrorMessage(error instanceof Error ? error.message : String(error));
+        throw error;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [],
+  );
 
   const getRecommendationResult = useCallback(async (id: string) => {
     setIsLoading(true);
@@ -63,24 +69,27 @@ const useLocations = (): useLocationsReturn => {
     }
   }, []);
 
-  const getRecommendation = useCallback(async (requestBody: RecommendationRequestBody) => {
-    setIsProgressLoading(true);
-    setData(initialData);
-    try {
-      const newId = await getRecommendationId(requestBody);
-      const newData = await getRecommendationResult(newId);
+  const getRecommendation = useCallback(
+    async (requestBody: RecommendationRequestBody) => {
+      setIsProgressLoading(true);
+      setData(initialData);
+      try {
+        const newId = await getRecommendationId(requestBody);
+        const newData = await getRecommendationResult(newId);
 
-      await new Promise((resolve) => setTimeout(resolve, 600));
+        await new Promise((resolve) => setTimeout(resolve, 600));
 
-      return { id: newId, data: newData };
-    } catch (error) {
-      setIsError(true);
-      setErrorMessage(error instanceof Error ? error.message : String(error));
-      throw error;
-    } finally {
-      setIsProgressLoading(false);
-    }
-  }, []);
+        return { id: newId, data: newData };
+      } catch (error) {
+        setIsError(true);
+        setErrorMessage(error instanceof Error ? error.message : String(error));
+        throw error;
+      } finally {
+        setIsProgressLoading(false);
+      }
+    },
+    [],
+  );
 
   return {
     data,
@@ -90,7 +99,7 @@ const useLocations = (): useLocationsReturn => {
     errorMessage,
     getRecommendationId,
     getRecommendationResult,
-    getRecommendation
+    getRecommendation,
   };
 };
 

--- a/frontend/src/entities/location/hooks/useLocations.ts
+++ b/frontend/src/entities/location/hooks/useLocations.ts
@@ -88,7 +88,7 @@ const useLocations = (): useLocationsReturn => {
         setIsProgressLoading(false);
       }
     },
-    [],
+    [getRecommendationId, getRecommendationResult],
   );
 
   return {

--- a/frontend/src/features/loading/components/baseLoading/BaseLoading.tsx
+++ b/frontend/src/features/loading/components/baseLoading/BaseLoading.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 
 import Logo from '@shared/components/logo/Logo';
 import { flex } from '@shared/styles/default.styled';
@@ -9,6 +9,14 @@ interface BaseLoadingProps {
   children?: React.ReactNode;
 }
 
+const StaticContent = memo(() => (
+  <div css={flex({ justify: 'center', align: 'center', gap: 10 })}>
+    <Logo type="white" />
+  </div>
+));
+
+StaticContent.displayName = 'StaticContent';
+
 function BaseLoading({ children }: BaseLoadingProps) {
   return (
     <div
@@ -17,14 +25,12 @@ function BaseLoading({ children }: BaseLoadingProps) {
           direction: 'column',
           justify: 'center',
           align: 'center',
-          gap: 10,
+          gap: 10
         }),
-        loading.container(),
+        loading.container()
       ]}
     >
-      <div css={flex({ justify: 'center', align: 'center', gap: 10 })}>
-        <Logo type="white" />
-      </div>
+      <StaticContent />
       {children}
     </div>
   );

--- a/frontend/src/features/loading/components/progressLoading/ProgressLoading.stories.ts
+++ b/frontend/src/features/loading/components/progressLoading/ProgressLoading.stories.ts
@@ -8,9 +8,9 @@ const meta = {
   component: ProgressLoading,
   decorators: [withLayout],
   parameters: {
-    layout: 'centered'
+    layout: 'centered',
   },
-  tags: ['autodocs']
+  tags: ['autodocs'],
 } satisfies Meta<typeof ProgressLoading>;
 
 export default meta;
@@ -18,12 +18,12 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    isComplete: false
-  }
+    isReadyToComplete: false,
+  },
 };
 
 export const Complete: Story = {
   args: {
-    isComplete: true
-  }
+    isReadyToComplete: true,
+  },
 };

--- a/frontend/src/features/loading/components/progressLoading/ProgressLoading.stories.ts
+++ b/frontend/src/features/loading/components/progressLoading/ProgressLoading.stories.ts
@@ -8,12 +8,22 @@ const meta = {
   component: ProgressLoading,
   decorators: [withLayout],
   parameters: {
-    layout: 'centered',
+    layout: 'centered'
   },
-  tags: ['autodocs'],
+  tags: ['autodocs']
 } satisfies Meta<typeof ProgressLoading>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    isComplete: false
+  }
+};
+
+export const Complete: Story = {
+  args: {
+    isComplete: true
+  }
+};

--- a/frontend/src/features/loading/components/progressLoading/ProgressLoading.tsx
+++ b/frontend/src/features/loading/components/progressLoading/ProgressLoading.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import BaseLoading from '@features/loading/components/baseLoading/BaseLoading';
 import { LOADING_TEXT } from '@features/loading/constant/loadingText';
 import Progressbar from '@features/progressbar/components/progressbar/Progressbar';
@@ -5,8 +7,18 @@ import { useProgress } from '@features/progressbar/hooks/useProgress';
 
 import ProgressText from '../progressText/ProgressText';
 
-function ProgressLoading() {
-  const { progress } = useProgress();
+interface ProgressLoadingProps {
+  isComplete: boolean;
+}
+
+function ProgressLoading({ isComplete }: ProgressLoadingProps) {
+  const { progress, complete } = useProgress({ initialProgress: 0, targetProgress: 90 });
+
+  useEffect(() => {
+    if (isComplete && progress < 100) {
+      complete();
+    }
+  }, [isComplete]);
 
   return (
     <BaseLoading>

--- a/frontend/src/features/loading/components/progressLoading/ProgressLoading.tsx
+++ b/frontend/src/features/loading/components/progressLoading/ProgressLoading.tsx
@@ -8,17 +8,20 @@ import { useProgress } from '@features/progressbar/hooks/useProgress';
 import ProgressText from '../progressText/ProgressText';
 
 interface ProgressLoadingProps {
-  isComplete: boolean;
+  isReadyToComplete: boolean;
 }
 
-function ProgressLoading({ isComplete }: ProgressLoadingProps) {
-  const { progress, complete } = useProgress({ initialProgress: 0, targetProgress: 90 });
+function ProgressLoading({ isReadyToComplete }: ProgressLoadingProps) {
+  const { progress, complete } = useProgress({
+    initialProgress: 0,
+    targetProgress: 90,
+  });
 
   useEffect(() => {
-    if (isComplete && progress < 100) {
+    if (isReadyToComplete && progress < 100) {
       complete();
     }
-  }, [isComplete]);
+  }, [isReadyToComplete]);
 
   return (
     <BaseLoading>

--- a/frontend/src/features/loading/components/progressLoading/ProgressLoading.tsx
+++ b/frontend/src/features/loading/components/progressLoading/ProgressLoading.tsx
@@ -18,10 +18,10 @@ function ProgressLoading({ isReadyToComplete }: ProgressLoadingProps) {
   });
 
   useEffect(() => {
-    if (isReadyToComplete && progress < 100) {
+    if (isReadyToComplete) {
       complete();
     }
-  }, [isReadyToComplete]);
+  }, [isReadyToComplete, complete]);
 
   return (
     <BaseLoading>

--- a/frontend/src/features/meeting/components/meetingForm/MeetingForm.tsx
+++ b/frontend/src/features/meeting/components/meetingForm/MeetingForm.tsx
@@ -25,11 +25,11 @@ function MeetingForm() {
     addDepartureWithValidation,
     removeDepartureAtIndex,
     updateConditionID,
-    validateFormSubmit
+    validateFormSubmit,
   } = useFormInfo();
   const { isVisible, message, showToast } = useToast();
 
-  const { getRecommendation } = useLocationsContext();
+  const { getRecommendationFull } = useLocationsContext();
 
   const showValidationError = (error: ValidationError) => {
     if (!error.isValid) {
@@ -60,9 +60,9 @@ function MeetingForm() {
     }
 
     try {
-      const { id } = await getRecommendation({
+      const { id } = await getRecommendationFull({
         startingPlaceNames: departureList,
-        requirement: conditionID
+        requirement: conditionID,
       });
 
       if (id) navigate(`/result/${id}`);

--- a/frontend/src/features/meeting/components/meetingForm/MeetingForm.tsx
+++ b/frontend/src/features/meeting/components/meetingForm/MeetingForm.tsx
@@ -25,11 +25,11 @@ function MeetingForm() {
     addDepartureWithValidation,
     removeDepartureAtIndex,
     updateConditionID,
-    validateFormSubmit,
+    validateFormSubmit
   } = useFormInfo();
   const { isVisible, message, showToast } = useToast();
 
-  const { getRecommendationId } = useLocationsContext();
+  const { getRecommendation } = useLocationsContext();
 
   const showValidationError = (error: ValidationError) => {
     if (!error.isValid) {
@@ -60,9 +60,9 @@ function MeetingForm() {
     }
 
     try {
-      const id = await getRecommendationId({
+      const { id } = await getRecommendation({
         startingPlaceNames: departureList,
-        requirement: conditionID,
+        requirement: conditionID
       });
 
       if (id) navigate(`/result/${id}`);

--- a/frontend/src/features/progressbar/components/progressbar/Progressbar.styled.ts
+++ b/frontend/src/features/progressbar/components/progressbar/Progressbar.styled.ts
@@ -13,7 +13,6 @@ export const container = () => css`
 export const bar = (progress: number) => css`
   width: ${progress}%;
   height: 100%;
-  transition: width 0.3s ease;
   background-color: ${colorToken.main[1]};
   border-radius: ${borderRadiusToken[10]};
 `;

--- a/frontend/src/features/progressbar/hooks/useProgress.ts
+++ b/frontend/src/features/progressbar/hooks/useProgress.ts
@@ -18,10 +18,10 @@ type UseProgressReturns = {
 export const useProgress = ({
   duration = 10000,
   initialProgress = PROGRESS_MIN_VALUE,
-  targetProgress = PROGRESS_MAX_VALUE
+  targetProgress = PROGRESS_MAX_VALUE,
 }: UseProgressParams = {}): UseProgressReturns => {
   const [progress, setProgress] = useState(initialProgress);
-  const animationRef = useRef<number>(null);
+  const animationRef = useRef<number | null>(null);
 
   const startTimeRef = useRef<number>(0);
 
@@ -46,7 +46,8 @@ export const useProgress = ({
         }
 
         const ratio = elapsed / duration;
-        const easedProgress = startProgress + (to - startProgress) * (1 - Math.pow(1 - ratio, 3));
+        const easedProgress =
+          startProgress + (to - startProgress) * (1 - Math.pow(1 - ratio, 3));
         const easedProgressNumber = Math.floor(easedProgress * 1000) / 1000;
         return easedProgressNumber;
       });
@@ -66,12 +67,22 @@ export const useProgress = ({
       throw new Error('duration must be greater than 0');
     }
 
-    if (initialProgress < PROGRESS_MIN_VALUE || initialProgress > PROGRESS_MAX_VALUE) {
-      throw new Error(`Initial progress must be between ${PROGRESS_MIN_VALUE} and ${PROGRESS_MAX_VALUE}`);
+    if (
+      initialProgress < PROGRESS_MIN_VALUE ||
+      initialProgress > PROGRESS_MAX_VALUE
+    ) {
+      throw new Error(
+        `Initial progress must be between ${PROGRESS_MIN_VALUE} and ${PROGRESS_MAX_VALUE}`,
+      );
     }
 
-    if (targetProgress < PROGRESS_MIN_VALUE || targetProgress > PROGRESS_MAX_VALUE) {
-      throw new Error(`Target progress must be between ${PROGRESS_MIN_VALUE} and ${PROGRESS_MAX_VALUE}`);
+    if (
+      targetProgress < PROGRESS_MIN_VALUE ||
+      targetProgress > PROGRESS_MAX_VALUE
+    ) {
+      throw new Error(
+        `Target progress must be between ${PROGRESS_MIN_VALUE} and ${PROGRESS_MAX_VALUE}`,
+      );
     }
 
     if (progress !== PROGRESS_MAX_VALUE) {
@@ -108,6 +119,6 @@ export const useProgress = ({
 
   return {
     progress,
-    complete
+    complete,
   };
 };

--- a/frontend/src/features/progressbar/hooks/useProgress.ts
+++ b/frontend/src/features/progressbar/hooks/useProgress.ts
@@ -59,10 +59,10 @@ export const useProgress = ({
   }, []);
 
   /**
-   * 프로그레스바의 기본 진행 애니메이션을 처리하는 effect
-   * 주의: 이미 PROGRESS_MAX_VALUE에 도달한 경우 애니메이션을 시작하지 않습니다.
+   * 파라미터 유효성 검사
+   * @throws {Error} - 파라미터가 유효하지 않은 경우 에러 발생
    */
-  useEffect(() => {
+  const validateParams = () => {
     if (duration <= 0) {
       throw new Error('duration must be greater than 0');
     }
@@ -84,6 +84,14 @@ export const useProgress = ({
         `Target progress must be between ${PROGRESS_MIN_VALUE} and ${PROGRESS_MAX_VALUE}`,
       );
     }
+  };
+
+  /**
+   * 프로그레스바의 기본 진행 애니메이션을 처리하는 effect
+   * 주의: 이미 PROGRESS_MAX_VALUE에 도달한 경우 애니메이션을 시작하지 않습니다.
+   */
+  useEffect(() => {
+    validateParams();
 
     if (progress !== PROGRESS_MAX_VALUE) {
       animate(duration, initialProgress, targetProgress);

--- a/frontend/src/features/progressbar/hooks/useProgress.ts
+++ b/frontend/src/features/progressbar/hooks/useProgress.ts
@@ -1,60 +1,113 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
-type UseProgressProps = {
+const PROGRESS_MIN_VALUE = 0; // 프로그레스바 최소 상태 값 (0%)
+const PROGRESS_MAX_VALUE = 100; // 프로그레스바 최대 상태 값 (100%)
+const PROGRESS_COMPLETE_DURATION = 500; // 프로그레스바 애니메이션 완료 시간 (밀리초)
+
+type UseProgressParams = {
   duration?: number;
   initialProgress?: number;
   targetProgress?: number;
 };
 
-type UseProgressReturn = {
+type UseProgressReturns = {
   progress: number;
   complete: () => void;
 };
 
 export const useProgress = ({
-  duration = 25000,
-  initialProgress = 0,
-  targetProgress = 90,
-}: UseProgressProps = {}): UseProgressReturn => {
+  duration = 10000,
+  initialProgress = PROGRESS_MIN_VALUE,
+  targetProgress = PROGRESS_MAX_VALUE
+}: UseProgressParams = {}): UseProgressReturns => {
   const [progress, setProgress] = useState(initialProgress);
+  const animationRef = useRef<number>(null);
 
-  useEffect(() => {
-    const startTime = Date.now();
-    let animationId: number;
+  const startTimeRef = useRef<number>(0);
 
-    const animationFrame = () => {
-      const currentTime = Date.now();
-      const elapsed = currentTime - startTime;
+  /**
+   * 프로그레스바의 애니메이션을 처리하는 함수
+   * @param duration - 애니메이션 지속 시간 (밀리초)
+   * @param from - 시작 진행률
+   * @param to - 목표 진행률
+   */
+  const animate = useCallback((duration: number, from: number, to: number) => {
+    startTimeRef.current = performance.now();
+    const startProgress = from;
 
-      if (elapsed >= duration) {
-        setProgress(targetProgress);
-        return;
-      }
+    const animationFrame = (currentTime: number) => {
+      setProgress((currentProgress) => {
+        if (currentProgress === to) return currentProgress;
 
-      const ratio = elapsed / duration;
-      const easedProgress = Math.min(
-        targetProgress,
-        targetProgress * (1 - Math.pow(1 - ratio, 3)),
-      );
+        const elapsed = currentTime - startTimeRef.current;
 
-      setProgress(easedProgress);
-      animationId = requestAnimationFrame(animationFrame);
+        if (elapsed >= duration) {
+          return to;
+        }
+
+        const ratio = elapsed / duration;
+        const easedProgress = startProgress + (to - startProgress) * (1 - Math.pow(1 - ratio, 3));
+        const easedProgressNumber = Math.floor(easedProgress * 1000) / 1000;
+        return easedProgressNumber;
+      });
+
+      animationRef.current = requestAnimationFrame(animationFrame);
     };
 
-    animationId = requestAnimationFrame(animationFrame);
+    animationRef.current = requestAnimationFrame(animationFrame);
+  }, []);
+
+  /**
+   * 프로그레스바의 기본 진행 애니메이션을 처리하는 effect
+   * 주의: 이미 PROGRESS_MAX_VALUE에 도달한 경우 애니메이션을 시작하지 않습니다.
+   */
+  useEffect(() => {
+    if (duration <= 0) {
+      throw new Error('duration must be greater than 0');
+    }
+
+    if (initialProgress < PROGRESS_MIN_VALUE || initialProgress > PROGRESS_MAX_VALUE) {
+      throw new Error(`Initial progress must be between ${PROGRESS_MIN_VALUE} and ${PROGRESS_MAX_VALUE}`);
+    }
+
+    if (targetProgress < PROGRESS_MIN_VALUE || targetProgress > PROGRESS_MAX_VALUE) {
+      throw new Error(`Target progress must be between ${PROGRESS_MIN_VALUE} and ${PROGRESS_MAX_VALUE}`);
+    }
+
+    if (progress !== PROGRESS_MAX_VALUE) {
+      animate(duration, initialProgress, targetProgress);
+    }
 
     return () => {
-      setProgress(initialProgress);
-      cancelAnimationFrame(animationId);
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
     };
-  }, [duration, initialProgress, targetProgress]);
+  }, []);
 
-  const complete = () => {
-    setProgress(100);
-  };
+  /**
+   * 프로그레스바를 즉시 완료 상태로 전환하는 함수
+   * 현재 진행률에서 PROGRESS_MAX_VALUE까지 PROGRESS_COMPLETE_DURATION 동안 애니메이션을 실행합니다.
+   *
+   * 주의:
+   * - 이미 PROGRESS_MAX_VALUE인 경우 아무 동작도 하지 않습니다.
+   * - 실행 중인 기존 애니메이션은 취소됩니다.
+   */
+  const complete = useCallback(() => {
+    setProgress((currentProgress) => {
+      if (currentProgress === PROGRESS_MAX_VALUE) return currentProgress;
+
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+
+      animate(PROGRESS_COMPLETE_DURATION, currentProgress, PROGRESS_MAX_VALUE);
+      return currentProgress;
+    });
+  }, [animate]);
 
   return {
     progress,
-    complete,
+    complete
   };
 };

--- a/frontend/src/pages/components/indexPage/IndexPage.tsx
+++ b/frontend/src/pages/components/indexPage/IndexPage.tsx
@@ -11,11 +11,21 @@ import { flex, grid_padding, scroll } from '@shared/styles/default.styled';
 import * as indexPage from './indexPage.styled';
 
 function IndexPage() {
-  const { isLoading, isError, errorMessage } = useLocationsContext();
+  const { data, isProgressLoading, isError, errorMessage } = useLocationsContext();
 
-  if (isLoading) return <ProgressLoading />;
   if (isError)
-    return <FallBackPage reset={() => {}} error={new Error(errorMessage)} />;
+    return (
+      <FallBackPage
+        reset={() => {
+          window.location.reload();
+        }}
+        error={new Error(errorMessage)}
+      />
+    );
+
+  if (isProgressLoading) {
+    return <ProgressLoading isComplete={isProgressLoading && data.recommendedLocations.length > 0} />;
+  }
   return (
     <div
       css={[

--- a/frontend/src/pages/components/indexPage/IndexPage.tsx
+++ b/frontend/src/pages/components/indexPage/IndexPage.tsx
@@ -15,14 +15,7 @@ function IndexPage() {
     useLocationsContext();
 
   if (isError)
-    return (
-      <FallBackPage
-        reset={() => {
-          window.location.reload();
-        }}
-        error={new Error(errorMessage)}
-      />
-    );
+    return <FallBackPage reset={() => {}} error={new Error(errorMessage)} />;
 
   if (isProgressLoading) {
     return (

--- a/frontend/src/pages/components/indexPage/IndexPage.tsx
+++ b/frontend/src/pages/components/indexPage/IndexPage.tsx
@@ -11,7 +11,8 @@ import { flex, grid_padding, scroll } from '@shared/styles/default.styled';
 import * as indexPage from './indexPage.styled';
 
 function IndexPage() {
-  const { data, isProgressLoading, isError, errorMessage } = useLocationsContext();
+  const { data, isProgressLoading, isError, errorMessage } =
+    useLocationsContext();
 
   if (isError)
     return (
@@ -24,7 +25,11 @@ function IndexPage() {
     );
 
   if (isProgressLoading) {
-    return <ProgressLoading isComplete={isProgressLoading && data.recommendedLocations.length > 0} />;
+    return (
+      <ProgressLoading
+        isComplete={isProgressLoading && data?.recommendedLocations?.length > 0}
+      />
+    );
   }
   return (
     <div

--- a/frontend/src/pages/components/indexPage/IndexPage.tsx
+++ b/frontend/src/pages/components/indexPage/IndexPage.tsx
@@ -27,7 +27,9 @@ function IndexPage() {
   if (isProgressLoading) {
     return (
       <ProgressLoading
-        isComplete={isProgressLoading && data?.recommendedLocations?.length > 0}
+        isReadyToComplete={
+          isProgressLoading && data?.recommendedLocations?.length > 0
+        }
       />
     );
   }


### PR DESCRIPTION
# #️⃣ Issue Number
#324 

## 🕹️ 작업 내용

한 줄 요약 : Progressbar 모션이 끝난 후 ResultPage로 리다이렉트 되도록 수정했어요

- [x] useProgress 훅을 개선 (commit : 21c0701a3ff815b798857689719c3390579c5ba3)
  - 프로그레스바의 기간, 최소 및 최대 값 상수 추가
  - 애니메이션 로직 개선 및 성능 최적화
  - 매개변수 유효성 검사 추가
  - 프로그레스바 즉시 완료 기능 (complete) 개선
- [x] Progressbar 컴포넌트를 개선 (commit : da5cbbf96a01673107be3b485bbc90e7c7e968fb )
  - useProgress 훅에서 `rAF` 과 Progressbar의 컴포넌트에서 css로 `transition`을 사용하고 있어서 `rAF` 만 사용하도록 수정
- [x] ProgressLoading 컴포넌트 렌더링 최적화를 위한 useLocations 훅 개선 (commit : e8e39873149fb4c63ef396c84577e34dae87fc4a)
  - useLocations 훅에서 getRecommendationId와 getRecommendationResult를 사용하는 getRecommendation 함수 추가
  - useLocation에서 isProgressLoading 상태를 추가하여 ProgressLoading 컴포넌트 렌더링 상태 개선
  - 변경된 useLocation 에 맞춰 MeetingForm의 handleSubmit 로직 변경
  - ProgressLoading 컴포넌트에 isComplete prop 추가 및 로딩 완료 시 상태 관리 개선
  - IndexPage에서 로딩 상태(isProgressLoading)에 따라 ProgressLoading 컴포넌트 변경
  - ResultPage에서 data 가 없는 경우 fetch하도록 로직 변경
- [x] BaseLoading 컴포넌트 렌더링 최적화 (commit : df6ad7f7d997971b3bc000ecac062d7141e8afd8)
  - BaseLoading 컴포넌트에서 로고 렌더링을 StaticContent로 분리하여 메모이제이션 적용하여 코드 성능 최적화

## 📋 리뷰 포인트

- [ ] 기존의 방식은 `indexPage>MeetingForm` 에서 `handleSubmit` 실행 시, `indePage`에서 `getRecommendationId`를 사용해 `id`를 받고, 이 `id`를 통해 `ResultPage`에서 `getRecommendationResult`를 사용해서 `location` 데이터를 받아왔어요. 자연스러운 `ProgressLoading` 컴포넌트의 렌더링을 위해 `getRecommendationId`의 동작과 `getRecommendationResult`의 동작을 일괄로 실행하는 `getRecommendation`를 추가했어요. 이 과정에서 불필요한 로직이나 코드가 있는지 확인해주세요.
- [ ] `ProgressLoading` 컴포넌트의 렌더링 과정에서 `BaseLoading` 컴포넌트의 Logo가 불필요하게 재렌더링이 일어나고 있어서 메모제이션을 통해 재렌더링을 방지했어요. 이에 대해 어떻게 생각하시는지 의견이 궁금해요. 
- [ ] 로컬에서 아래의 의도대로 잘 동작하는지 확인해주세요.

## 📸 스크린샷
![화면 기록 2025-09-11 오후 8 45 24](https://github.com/user-attachments/assets/60412aa1-f454-453b-bdef-895cb0cfc14e)
- 스크린샷의 의도는 아래와 같습니다. 
  - 첫 요청 시 ProgressLoading의 게이지가 100까지 찬 후 ResultPage로 렌더링 된다. 
  - 이후 다시 IndexPage에서 재요청을 보내도 의도대로 ProgressLoading의 게이지가 100까지 찬 후 ResultPage로 렌더링 된다. 
  - 렌더링된 ResultPage에서 새로고침하여도 `url`의 `id`를 통해 location의 데이터를 fetch해 올 수 있다.

## 🔮 기타 사항

- 추후에 브라우저의 localStorage에서 id에 대한 data를 캐싱하여, 성능 최적화 관련 팀 요구사항을 만족할 수 있을 것 같습니다!

- 프로그레스바 애니메이션 구현 개선 방안
  - 기존 프로그레스바의 애니메이션은 requestAnimationFrame(rAF)을 통한 JavaScript 기반 애니메이션과 CSS transition 속성이 중복 적용되어 있었어요. rAF는 JavaScript 레벨에서 progress 상태값을 점진적으로 변경하고, CSS transition은 동일한 width 속성 변화에 대해 또다시 보간(interpolation)을 수행하고 있어 불필요한 이중 애니메이션이 발생해요. 
  - 이를 개선하기 위해 CSS transition을 제거하고 rAF만을 사용하여 애니메이션을 구현하면, 단일 애니메이션 레이어에서 더 정확하고 효율적인 진행률 표시가 가능해요. 
  - 이는 브라우저의 렌더링 최적화에 도움을 주며, 특히 저사양 디바이스에서 더 부드러운 애니메이션 효과를 기대할 수 있어요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 글로벌 진행 상태(isProgressLoading) 및 진행 완료 플래그(isReadyToComplete) 도입.
  * 추천 호출이 전체 응답({id, data})을 반환하도록 확장되어 호출 결과 사용 방식이 변경됨.

* **리팩터**
  * 진행 애니메이션을 RAF 기반으로 재작성하고 완료 트리거(complete) 추가.
  * 페이지 로딩/오류 처리 흐름 정리 및 로딩 컴포넌트의 정적 콘텐츠를 메모이제이션 처리.

* **스타일**
  * 진행 막대의 너비 애니메이션 제거.

* **테스트**
  * 추천 결과 테스트에서 반환 데이터 검증 방식 조정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->