### PR TITLE
[FE] style: RouteCardBar 텍스트 깨짐 수정

### DIFF
--- a/frontend/src/features/recommendation/components/routeCardBar/routeCardBar.styled.ts
+++ b/frontend/src/features/recommendation/components/routeCardBar/routeCardBar.styled.ts
@@ -24,6 +24,8 @@ export const path = (
   totalTravelTime: number,
 ) => css`
   width: ${(travelTime / totalTravelTime) * 100}%;
+  min-width: 30px;
+  flex-shrink: 1;
   height: 15px;
   padding: 0 5px;
   background-color: ${lineCode
@@ -34,4 +36,5 @@ export const path = (
 
 export const text = (lineCode: string) => css`
   color: ${lineCode ? colorToken.gray[8] : colorToken.gray[5]};
+  white-space: nowrap;
 `;

--- a/frontend/src/features/recommendation/components/routeCardBar/routeCardBar.styled.ts
+++ b/frontend/src/features/recommendation/components/routeCardBar/routeCardBar.styled.ts
@@ -24,7 +24,7 @@ export const path = (
   totalTravelTime: number,
 ) => css`
   width: ${(travelTime / totalTravelTime) * 100}%;
-  min-width: 30px;
+  min-width: fit-content;
   flex-shrink: 1;
   height: 15px;
   padding: 0 5px;
@@ -35,6 +35,7 @@ export const path = (
 `;
 
 export const text = (lineCode: string) => css`
+  margin: 0 3px;
   color: ${lineCode ? colorToken.gray[8] : colorToken.gray[5]};
   white-space: nowrap;
 `;


### PR DESCRIPTION
# #️⃣ Issue Number
#314 

## 🕹️ 작업 내용

한 줄 요약 :
ResultPage의 상세보기 탭에서 경로바(`RouteCardBar`)에서 텍스트 깨짐 문제 발생하여 해결했어요.

- [x]  routeCardBar 컴포넌트에 최소 너비 설정 및 flex-shrink 추가, 텍스트에 줄 바꿈 방지 설정

| before | after (min-width: 30px)`현재 선택` | after (min-width: fit-content) `고민됨` |
|------|------|------|
|  <img width="387" height="325" alt="스크린샷 2025-09-17 오후 3 14 18" src="https://github.com/user-attachments/assets/a9834f07-3be7-4db8-b028-da848a8756a7" />  | <img width="378" height="254" alt="스크린샷 2025-09-17 오후 3 40 17" src="https://github.com/user-attachments/assets/674ab82e-d6c5-42bb-9f35-12f2d27d79fc" /> | <img width="386" height="323" alt="스크린샷 2025-09-17 오후 3 39 55" src="https://github.com/user-attachments/assets/a1a2be80-1c24-4758-9b07-3d7f48d3b071" /> |

## 📋 리뷰 포인트

- [x] 모바일, 데스크탑 뷰에서 `RouteCardBar`의 텍스트가 깨지지 않고 잘 보여지는지 확인해주세요.
- [x] 현재 css 속성 외의 더 나은 다른 해결책이있다면 공유해주세요.

## 🤔 논의하고 싶은 내용
위에 사진에서 보이는 것처럼 min-width를 30px로 고정할지, fit-content로 설정할지 고민이 돼요. 이에 대한 헤일리의 의견이 궁금합니다.

감사합니다 ! 🙇‍♂️

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved route card bar layout for better readability and consistency.
  * Ensured bars maintain intrinsic minimum width and can shrink appropriately in responsive layouts.
  * Prevented route labels from wrapping and added subtle horizontal spacing for clearer labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->