### PR TITLE
[FE] chore: coderabbit 추가 commit 자동 리뷰 비활성화

### DIFF
--- a/.github/.coderabbit.yaml
+++ b/.github/.coderabbit.yaml
@@ -9,3 +9,4 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    ignore_updates: true


### PR DESCRIPTION
# #️⃣ Issue Number
#344 

## 🕹️ 작업 내용

배경 : 기존에 코드래빗에서 추가 커밋과 같은 업데이트 발생시, 자동 리뷰가 되고 있었어요.
한 줄 요약 : 코드래빗의 PR 자동 리뷰 설정에서 업데이트에 대해 자동 리뷰를 비활성화했어요.

- [ ] 코드레빗 PR 자동 리뷰 설정에서 업데이트 무시 옵션 추가

## 📋 리뷰 포인트

- [ ] 의도에 맞는 환경 설정인지 확인해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated automated review configuration to refine how update events are handled in continuous review workflows. This change streamlines internal review noise and stabilizes CI feedback cycles. There are no user-facing changes, feature additions, or behavior modifications in the application as a result of this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->