### PR TITLE
[FE] fix: 너비가 좁은 화면에서 Toast 메시지가 줄바꿈 되는 이슈 해결

### DIFF
--- a/frontend/src/features/toast/components/Toast.tsx
+++ b/frontend/src/features/toast/components/Toast.tsx
@@ -23,7 +23,7 @@ function Toast({ message, isVisible }: ToastProps) {
         ]}
       >
         <img src={IconToast} alt="icon-toast" />
-        <div css={[toast.text(), typography.b1]}>{message}</div>
+        <span css={[toast.text(), typography.b1]}>{message}</span>
       </div>
     </div>,
     document.body,

--- a/frontend/src/features/toast/components/toast.styled.ts
+++ b/frontend/src/features/toast/components/toast.styled.ts
@@ -1,6 +1,8 @@
 import { css, keyframes } from '@emotion/react';
 
-import { borderRadiusToken, colorToken } from '@shared/styles/tokens';
+import { borderRadiusToken, colorToken, layout } from '@shared/styles/tokens';
+
+console.log(layout.minWidth);
 
 const slideDown = () => keyframes`
   0% {
@@ -23,6 +25,7 @@ const slideDown = () => keyframes`
 
 export const container = () => css`
   width: max-content;
+  max-width: calc(${layout.minWidth} - 40px);
   position: fixed;
   top: 20px;
   left: 50%;

--- a/frontend/src/features/toast/components/toast.styled.ts
+++ b/frontend/src/features/toast/components/toast.styled.ts
@@ -22,7 +22,7 @@ const slideDown = () => keyframes`
 `;
 
 export const container = () => css`
-  width: fit-content;
+  width: max-content;
   position: fixed;
   top: 20px;
   left: 50%;

--- a/frontend/src/features/toast/components/toast.styled.ts
+++ b/frontend/src/features/toast/components/toast.styled.ts
@@ -2,8 +2,6 @@ import { css, keyframes } from '@emotion/react';
 
 import { borderRadiusToken, colorToken, layout } from '@shared/styles/tokens';
 
-console.log(layout.minWidth);
-
 const slideDown = () => keyframes`
   0% {
     transform: translateY(-100%);

--- a/frontend/src/features/toast/components/toast.styled.ts
+++ b/frontend/src/features/toast/components/toast.styled.ts
@@ -34,7 +34,7 @@ export const container = () => css`
 `;
 
 export const content = () => css`
-  min-width: calc(100%);
+  min-width: 100%;
   padding: 10px 12px;
   text-align: center;
   background-color: ${colorToken.gray[7]};
@@ -43,5 +43,8 @@ export const content = () => css`
 `;
 
 export const text = () => css`
+  white-space: normal;
+  word-break: keep-all;
+  overflow-wrap: break-word;
   color: ${colorToken.gray[3]};
 `;

--- a/frontend/src/shared/styles/tokens.css
+++ b/frontend/src/shared/styles/tokens.css
@@ -77,4 +77,5 @@
 
   /* 공통 너비 */
   --layout-max-width: 400px;
+  --layout-min-width: 320px;
 }

--- a/frontend/src/shared/styles/tokens.ts
+++ b/frontend/src/shared/styles/tokens.ts
@@ -92,6 +92,7 @@ const borderRadiusToken = {
 
 const layout = {
   maxWidth: 'var(--layout-max-width)',
+  minWidth: 'var(--layout-min-width)',
   media_maxWidth: '400px',
 };
 


### PR DESCRIPTION
#️⃣ Issue Number

#354 

## 🕹️ 작업 내용
- 배경/문제: 화면 사이즈가 일정 수준 이하로 줄어들면, 토스트 메시지 UI 안의 글자가 예상치 못하게 줄바꿈되는 문제가 발생했습니다.
- 목표/의도: 작은 화면에서도 토스트 메시지가 의도한대로 표시되도록 UI를 개선하겠습니다.
- [x] 화면 뷰포트 width 최솟값을 `320px`로 설정했습니다. 
- [x] 토스트의 width 최대값을 `280px`로 설정했습니다.
- [x] 토스트 안에 글자가 width 최대값을 넘어가면 단어의 끝에서만 줄바꿈이 됩니다. (= 문장의 마지막 공백을 기준으로 줄바꿈이 됩니다.)

## 🎨 Before / After (Optional)
<!-- UI/UX 변경이 있다면 스크린샷, GIF 첨부 -->
| Before (320px) | After (320px) |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/92f8e72b-d243-449c-ab0b-7b881bde63d0) | ![after](https://github.com/user-attachments/assets/99422626-0972-4b48-8093-53d497243ad8)


## 🔍 리뷰 포인트

<!-- 리뷰어가 집중해야 할 부분 -->
- [ ] 시나리오대로 정상적으로 동작하는지 확인해주세요.
  - [ ] 토스트 안에 글자가 토스트 width 최대값인 `280px`을 넘을 때 👉 단어의 끝에서만 줄 바꿈이 된다. 토스트의 길이는 `280px`이다.
  - [ ] 토스트 안에 글자가 토스트 width 최대값인 `280px`을 넘지 않을 때 👉 토스트의 길이는 글자에 맞춰진다.

## 📎 참고 - 해결과정 (Optional)

- 문제의식: 화면 사이즈가 일정 수준 이하로 줄어들면, 토스트 메시지 UI 안의 글자가 예상치 못하게 줄바꿈되는 문제가 발생한다.
- 해결방법 - 가설 1: 메시지 길이에 맞춰 width를 늘린다.
  - ❌ 문제: 메시지가 너무 길면 토스트가 화면의 width를 벗어나 버릴 수 있다.
- 해결방법 - 가설 2: 문장의 공백(띄어쓰기)을 기준으로 줄바꿈한다.
  - ❌ 문제: 메시지가 길 경우 줄바꿈이 과도하게 발생(3줄 이상) → UX 저하.
- 해결방법 - 가설 3(채택): 최소 뷰포트 width를 정한다. 
   -  ✅ 방식: 최소 뷰포트 기준을 두고, 메시지가 그 너비를 넘으면 줄바꿈 처리.
    - ✅ 장점: 메시지가 짧으면 글자 길이에 맞게 자연스럽게 보이고, 메시지가 길면 최대 width 내에서 줄바꿈 처리.