### PR TITLE
[BE] 개발 환경 CI/CD 스크립트 수정

### DIFF
--- a/.github/workflows/be-cicd-dev-auto-trigger.yml
+++ b/.github/workflows/be-cicd-dev-auto-trigger.yml
@@ -32,7 +32,7 @@ jobs:
           rm -rf src/main/resources/application-db.properties
           echo "$APPLICATION_DB_PROPERTIES" > src/main/resources/application-db.properties
 
-          ./gradlew --no-build-cache clean build --refresh-dependencies
+          ./gradlew --no-build-cache clean build --refresh-dependencies -Dspring.profiles.active=dev
 
           if [ $? -ne 0 ]; then
             echo "빌드 실패"


### PR DESCRIPTION
# #️⃣ Issue Number

## 🕹️ 작업 내용

한 줄 요약 : 빌드 시에 Spring profile을 dev로 지정하는 설정 추가

- AS-IS: ./gradlew --no-build-cache clean build --refresh-dependencies
- TO-BE: ./gradlew --no-build-cache clean build --refresh-dependencies -Dspring.profiles.active=dev


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI 파이프라인에서 빌드 시 개발 프로필이 활성화되도록 설정을 조정했습니다. 애플리케이션의 기능, UI, 및 외부 API 동작에는 변화가 없습니다. 빌드 이후 단계와 배포 산출물은 기존과 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->