### PR TITLE
[BE] fix: 지하철 역 이름 파싱 오류 수정

### DIFF
--- a/backend/src/main/java/com/f12/moitz/infrastructure/client/open/OpenApiClient.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/client/open/OpenApiClient.java
@@ -125,9 +125,8 @@ public class OpenApiClient {
     }
 
     private String getStationName(final String stationName) {
-        if (!"서울역".equals(stationName) && stationName.contains("역")) {
-            final int index = stationName.indexOf("역");
-            return stationName.substring(0, index);
+        if (!"서울역".equals(stationName) && stationName.endsWith("역")) {
+            return stationName.substring(0, stationName.length() - 1);
         }
         return stationName;
     }

--- a/backend/src/test/java/com/f12/moitz/MoitzApplicationTests.java
+++ b/backend/src/test/java/com/f12/moitz/MoitzApplicationTests.java
@@ -1,20 +1,13 @@
 package com.f12.moitz;
 
-import com.f12.moitz.application.SetupService;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 class MoitzApplicationTests {
 
-    @MockitoBean
-    private SetupService setupService;
-
     @Test
     void contextLoads() {
-        Mockito.doNothing().when(setupService).setup();
     }
 
 }


### PR DESCRIPTION
# #️⃣ Issue Number

## 🕹️ 작업 내용

한 줄 요약 : 지하철 역 이름 파싱 오류를 수정합니다.

- [x] "역" 자가 들어가는 역 이름 파싱 시 지하철 역 이름 전체가 누락되는 현상 수정(예: 역삼)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 역 이름 표기 로직 개선: 이름에 ‘역’이 중간에 포함된 경우 잘못 잘리던 문제를 수정했습니다. 이제 이름이 ‘…역’으로 끝날 때에만 접미사 ‘역’을 제거하여 표기합니다. 검색, 목록, 상세 화면 등에서 역 이름이 보다 정확하게 표시됩니다.

* **Tests**
  * 불필요한 목 설정을 제거하고 테스트를 간소화하여 유지보수성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->