### PR TITLE
[FE] feat: 선택한 위치 마커(상세 보기 상태) 재클릭시 리스트 상태로 변경

### DIFF
--- a/frontend/src/pages/hooks/useSelectedLocation.ts
+++ b/frontend/src/pages/hooks/useSelectedLocation.ts
@@ -14,7 +14,12 @@ const useSelectedLocation = (): useSelectedLocationReturn => {
     useState<SelectedLocation>(null);
 
   const changeSelectedLocation = (location: SelectedLocation) => {
-    setSelectedLocation(location);
+    setSelectedLocation((prevLocation) => {
+      if (prevLocation === location) {
+        return null;
+      }
+      return location;
+    });
   };
 
   return { selectedLocation, changeSelectedLocation };


### PR DESCRIPTION
# #️⃣ Issue Number
#340 

## 🕹️ 작업 내용

배경 : 변경 전에는 선택한 추천 위치 마커를 클릭하면 상세보기 상태로 변경되지만, 재클릭시 상호작용이 없었어요.
한 줄 요약 : 선택한 추천 위치 마커를 클릭시 상세보기 상태에서 리스트 상태로 변경했어요.

- [x] selectedLocation에서 동일한 위치가 선택될 경우 선택 해제 기능 추가

## 📸 스크린샷

| Before | After |
|-------|-------|
| ![화면 기록 2025-09-23 오후 4 10 26](https://github.com/user-attachments/assets/08648ce3-f1d4-4c15-bf8d-b749e833602d) | ![화면 기록 2025-09-23 오후 4 10 41](https://github.com/user-attachments/assets/f9fee32a-59d2-4bb3-a48c-599811185ae6) |

## 📋 리뷰 포인트

- [ ] 데스크탑뷰, 모바일뷰에서 모두 의도대로 동작하는지 확인해주세요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Location selection now toggles: selecting an already selected location will deselect it. This streamlines switching or clearing a location without extra taps/clicks and reduces friction during navigation or filtering.
* **Behavior Changes**
  * Repeatedly selecting the same location no longer keeps it selected; it clears the selection instead. No visual UI changes, but interaction is smoother and more predictable for quick deselection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->