### PR TITLE
[BE] fix: 지하철 역 이름에 "이수"가 포함될 경우 검색 실패하는 오류 수정

### DIFF
--- a/backend/src/main/java/com/f12/moitz/application/SubwayStationService.java
+++ b/backend/src/main/java/com/f12/moitz/application/SubwayStationService.java
@@ -33,7 +33,7 @@ public class SubwayStationService {
     }
 
     public Optional<SubwayStation> findByName(final String name) {
-        if (name.contains("이수")) {
+        if ("이수역".equals(name)) {
             return subwayStationRepository.findByName("총신대입구역");
         }
         return subwayStationRepository.findByName(name);

--- a/backend/src/main/java/com/f12/moitz/application/SubwayStationService.java
+++ b/backend/src/main/java/com/f12/moitz/application/SubwayStationService.java
@@ -33,6 +33,9 @@ public class SubwayStationService {
     }
 
     public Optional<SubwayStation> findByName(final String name) {
+        if (name.contains("이수")) {
+            return subwayStationRepository.findByName("총신대입구역");
+        }
         return subwayStationRepository.findByName(name);
     }
 

--- a/backend/src/test/java/com/f12/moitz/application/SubwayStationServiceTest.java
+++ b/backend/src/test/java/com/f12/moitz/application/SubwayStationServiceTest.java
@@ -23,7 +23,7 @@ class SubwayStationServiceTest {
     @InjectMocks
     private SubwayStationService subwayStationService;
 
-    @DisplayName("'이수'가 포함된 이름으로 지하철 역 검색 시 총신대입구역을 반환한다.")
+    @DisplayName("'이수역'으로 지하철 역 검색 시 총신대입구역을 반환한다.")
     @Test
     void convertName() {
         // Given
@@ -33,14 +33,11 @@ class SubwayStationServiceTest {
         Mockito.when(subwayStationRepository.findByName("총신대입구역")).thenReturn(Optional.of(expectedStation));
 
         // When
-        final Optional<SubwayStation> station1 = subwayStationService.findByName("이수");
-        final Optional<SubwayStation> station2 = subwayStationService.findByName("이수역");
+        final Optional<SubwayStation> station = subwayStationService.findByName("이수역");
 
         // Then
-        assertThat(station1).contains(expectedStation);
-        assertThat(station1.get().getName()).isEqualTo(expectedName);
-        assertThat(station2).contains(expectedStation);
-        assertThat(station2.get().getName()).isEqualTo(expectedName);
+        assertThat(station).contains(expectedStation);
+        assertThat(station.get().getName()).isEqualTo(expectedName);
     }
 
 }

--- a/backend/src/test/java/com/f12/moitz/application/SubwayStationServiceTest.java
+++ b/backend/src/test/java/com/f12/moitz/application/SubwayStationServiceTest.java
@@ -1,0 +1,45 @@
+package com.f12.moitz.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.f12.moitz.domain.Point;
+import com.f12.moitz.domain.repository.SubwayStationRepository;
+import com.f12.moitz.domain.subway.SubwayStation;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SubwayStationServiceTest {
+
+    @Mock
+    private SubwayStationRepository subwayStationRepository;
+
+    @InjectMocks
+    private SubwayStationService subwayStationService;
+
+    @DisplayName("'이수'가 포함된 이름으로 지하철 역 검색 시 총신대입구역을 반환한다.")
+    @Test
+    void convertName() {
+        // Given
+        final String expectedName = "총신대입구역";
+        final SubwayStation expectedStation = new SubwayStation(expectedName, new Point(125, 34));
+
+        Mockito.when(subwayStationRepository.findByName("이수")).thenReturn(Optional.of(expectedStation));
+        Mockito.when(subwayStationRepository.findByName("이수역")).thenReturn(Optional.of(expectedStation));
+
+        // When
+        String actualName1 = subwayStationService.getByName("이수").getName();
+        String actualName2 = subwayStationService.getByName("이수역").getName();
+
+        // Then
+        assertThat(actualName1).isEqualTo(expectedName);
+        assertThat(actualName2).isEqualTo(expectedName);
+    }
+
+}

--- a/backend/src/test/java/com/f12/moitz/application/SubwayStationServiceTest.java
+++ b/backend/src/test/java/com/f12/moitz/application/SubwayStationServiceTest.java
@@ -30,16 +30,17 @@ class SubwayStationServiceTest {
         final String expectedName = "총신대입구역";
         final SubwayStation expectedStation = new SubwayStation(expectedName, new Point(125, 34));
 
-        Mockito.when(subwayStationRepository.findByName("이수")).thenReturn(Optional.of(expectedStation));
-        Mockito.when(subwayStationRepository.findByName("이수역")).thenReturn(Optional.of(expectedStation));
+        Mockito.when(subwayStationRepository.findByName("총신대입구역")).thenReturn(Optional.of(expectedStation));
 
         // When
-        String actualName1 = subwayStationService.getByName("이수").getName();
-        String actualName2 = subwayStationService.getByName("이수역").getName();
+        final Optional<SubwayStation> station1 = subwayStationService.findByName("이수");
+        final Optional<SubwayStation> station2 = subwayStationService.findByName("이수역");
 
         // Then
-        assertThat(actualName1).isEqualTo(expectedName);
-        assertThat(actualName2).isEqualTo(expectedName);
+        assertThat(station1).contains(expectedStation);
+        assertThat(station1.get().getName()).isEqualTo(expectedName);
+        assertThat(station2).contains(expectedStation);
+        assertThat(station2.get().getName()).isEqualTo(expectedName);
     }
 
 }


### PR DESCRIPTION
# #️⃣ Issue Number
#370 
## 🕹️ 작업 내용

한 줄 요약 : "이수"가 포함된 이름으로 지하철 역 검색 시 실패하는 오류 수정

- [x] "이수"를 포함하는 이름으로 지하철 역 검색 시 "총신대입구역"을 반환한다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * “이수”/“이수역”으로 검색하거나 조회할 때 이제 “총신대입구역”으로 정상 매칭되어 잘못된 결과나 누락이 발생하지 않습니다. 역 상세 보기, 모임 장소 지정 등 역 기반 기능 전반에서 일관된 결과를 제공합니다.
* 테스트
  * 해당 역명 매핑 동작을 검증하는 단위 테스트를 추가해 다양한 입력에서도 기대한 역명이 반환됨을 확인했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->