### PR TITLE
[BE] fix: 404로 반환하지 않던 오류 수정

### DIFF
--- a/backend/src/main/java/com/f12/moitz/application/RecommendationService.java
+++ b/backend/src/main/java/com/f12/moitz/application/RecommendationService.java
@@ -109,7 +109,7 @@ public class RecommendationService {
                 placeRoutes
         );
         stopWatch.stop();
-        log.debug("추천 서비스 완료. {}", stopWatch.shortSummary());
+        log.debug("추천 서비스 완료. {}", stopWatch.prettyPrint());
 
         return recommendResultRepository.saveAndReturnId(
                 recommendationMapper.toResult(
@@ -123,7 +123,7 @@ public class RecommendationService {
     private List<SubwayStation> getByNames(final List<String> names) {
         return names.stream()
                 .map(name -> subwayStationService.findByName(name)
-                        .orElseThrow(() -> new BadRequestException(GeneralErrorCode.INPUT_INVALID_START_LOCATION)))
+                        .orElseThrow(() -> new BadRequestException(GeneralErrorCode.INPUT_INVALID_START_LOCATION, name)))
                 .toList();
     }
 
@@ -167,9 +167,17 @@ public class RecommendationService {
     }
 
     public RecommendationsResponse getById(final String id) {
-        final Result result = recommendResultRepository.findById(new ObjectId(id))
+        final Result result = recommendResultRepository.findById(parseObjectId(id))
                 .orElseThrow(() -> new NotFoundException(GeneralErrorCode.INPUT_INVALID_RESULT));
         return recommendationMapper.toResponse(result);
+    }
+
+    private ObjectId parseObjectId(final String id) {
+        try {
+            return new ObjectId(id);
+        } catch (IllegalArgumentException e) {
+            throw new NotFoundException(GeneralErrorCode.INPUT_INVALID_RESULT);
+        }
     }
 
 }

--- a/backend/src/main/java/com/f12/moitz/application/RecommendationService.java
+++ b/backend/src/main/java/com/f12/moitz/application/RecommendationService.java
@@ -109,7 +109,7 @@ public class RecommendationService {
                 placeRoutes
         );
         stopWatch.stop();
-        log.debug("추천 서비스 완료. {}", stopWatch.prettyPrint());
+        log.debug("추천 서비스 완료. {}", stopWatch.shortSummary());
 
         return recommendResultRepository.saveAndReturnId(
                 recommendationMapper.toResult(
@@ -123,7 +123,7 @@ public class RecommendationService {
     private List<SubwayStation> getByNames(final List<String> names) {
         return names.stream()
                 .map(name -> subwayStationService.findByName(name)
-                        .orElseThrow(() -> new BadRequestException(GeneralErrorCode.INPUT_INVALID_START_LOCATION, name)))
+                        .orElseThrow(() -> new BadRequestException(GeneralErrorCode.INPUT_INVALID_START_LOCATION)))
                 .toList();
     }
 
@@ -167,17 +167,9 @@ public class RecommendationService {
     }
 
     public RecommendationsResponse getById(final String id) {
-        final Result result = recommendResultRepository.findById(parseObjectId(id))
+        final Result result = recommendResultRepository.findById(new ObjectId(id))
                 .orElseThrow(() -> new NotFoundException(GeneralErrorCode.INPUT_INVALID_RESULT));
         return recommendationMapper.toResponse(result);
-    }
-
-    private ObjectId parseObjectId(final String id) {
-        try {
-            return new ObjectId(id);
-        } catch (IllegalArgumentException e) {
-            throw new NotFoundException(GeneralErrorCode.INPUT_INVALID_RESULT);
-        }
     }
 
 }

--- a/backend/src/main/java/com/f12/moitz/application/dto/RecommendationRequest.java
+++ b/backend/src/main/java/com/f12/moitz/application/dto/RecommendationRequest.java
@@ -19,7 +19,7 @@ public record RecommendationRequest(
 
         private void validate(final List<String> startingPlaceNames) {
                 if (startingPlaceNames == null || startingPlaceNames.isEmpty()) {
-                        throw new BadRequestException(GeneralErrorCode.INPUT_INVALID_START_LOCATION);
+                        throw new BadRequestException(GeneralErrorCode.INPUT_INVALID_START_LOCATION, startingPlaceNames);
                 }
         }
 

--- a/backend/src/main/java/com/f12/moitz/common/error/exception/BadRequestException.java
+++ b/backend/src/main/java/com/f12/moitz/common/error/exception/BadRequestException.java
@@ -14,7 +14,7 @@ public class BadRequestException extends RuntimeException {
     }
 
     public BadRequestException(ErrorCode errorCode, Object... args) {
-        super(errorCode.getMessage() + " " +Arrays.toString(args));
+        super(errorCode.getMessage() + " " + Arrays.toString(args));
         this.errorCode = errorCode;
     }
 

--- a/backend/src/main/java/com/f12/moitz/common/error/exception/BadRequestException.java
+++ b/backend/src/main/java/com/f12/moitz/common/error/exception/BadRequestException.java
@@ -1,5 +1,6 @@
 package com.f12.moitz.common.error.exception;
 
+import java.util.Arrays;
 import lombok.Getter;
 
 @Getter
@@ -13,7 +14,7 @@ public class BadRequestException extends RuntimeException {
     }
 
     public BadRequestException(ErrorCode errorCode, Object... args) {
-        super(String.format(errorCode.getMessage(), args));
+        super(errorCode.getMessage() + " " +Arrays.toString(args));
         this.errorCode = errorCode;
     }
 

--- a/backend/src/main/java/com/f12/moitz/common/error/exception/GeneralErrorCode.java
+++ b/backend/src/main/java/com/f12/moitz/common/error/exception/GeneralErrorCode.java
@@ -3,10 +3,10 @@ package com.f12.moitz.common.error.exception;
 public enum GeneralErrorCode implements ErrorCode {
 
     // CLIENT 예외 C000
-    INPUT_INVALID_START_LOCATION("C0001", "유효하지 않은 출발지입니다. : %s"),
-    INPUT_INVALID_ARRIVAL_TIME("C0002", "유효하지 않은 도착시간입니다. : %s"),
-    INPUT_INVALID_DESCRIPTION("C0003", "유효하지 않은 성격입니다. : %s"),
-    INPUT_INVALID_RESULT("C0004", "존재하지 않거나 유효 기간이 만료된 추천 결과입니다. : %s");
+    INPUT_INVALID_START_LOCATION("C0001", "유효하지 않은 출발지입니다."),
+    INPUT_INVALID_ARRIVAL_TIME("C0002", "유효하지 않은 도착시간입니다."),
+    INPUT_INVALID_DESCRIPTION("C0003", "유효하지 않은 성격입니다."),
+    INPUT_INVALID_RESULT("C0004", "존재하지 않거나 유효 기간이 만료된 추천 결과입니다.");
 
     private final String code;
     private final String message;

--- a/backend/src/main/java/com/f12/moitz/common/error/exception/NotFoundException.java
+++ b/backend/src/main/java/com/f12/moitz/common/error/exception/NotFoundException.java
@@ -12,9 +12,4 @@ public class NotFoundException extends RuntimeException {
         this.errorCode = errorCode;
     }
 
-    public NotFoundException(ErrorCode errorCode, Object... args) {
-        super(String.format(errorCode.getMessage(), args));
-        this.errorCode = errorCode;
-    }
-
 }

--- a/backend/src/test/java/com/f12/moitz/domain/RecommendConditionTest.java
+++ b/backend/src/test/java/com/f12/moitz/domain/RecommendConditionTest.java
@@ -31,6 +31,6 @@ class RecommendConditionTest {
         // When & Then
         assertThatThrownBy(() -> RecommendCondition.fromTitle(invalidTitle))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage("유효하지 않은 성격입니다. : " + invalidTitle);
+                .hasMessage("유효하지 않은 성격입니다. [" + invalidTitle + "]");
     }
 }


### PR DESCRIPTION
# #️⃣ Issue Number
#381 

## 🕹️ 작업 내용

한 줄 요약 : 존재하지 않는 결과 조회 시 특정 상황에서 404로 반환하지 못하는 에러 수정

- [ ] ObjectId로 Convert 로직 추가
- [ ] 해당 로직에서 예외 캐칭

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 잘못된 요청 시 입력값(시작 장소 목록)을 오류 메시지에 포함해 표시.
- 버그 수정
  - 일반 오류 메시지의 포맷 플레이스홀더를 제거해 가독성과 일관성 개선.
  - Not Found 오류 메시지를 고정 포맷으로 통일.
- 테스트
  - 변경된 오류 메시지 포맷(대괄호 표기 등)에 맞춰 테스트 기대값 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->