### PR TITLE
[FE] perf: 로딩화면에서 발생하는 layout shift를 최소화

### DIFF
--- a/frontend/src/features/loading/components/progressText/ProgressText.tsx
+++ b/frontend/src/features/loading/components/progressText/ProgressText.tsx
@@ -20,7 +20,7 @@ function ProgressText({ text }: ProgressTextProps) {
   }, []);
 
   return (
-    <div
+    <span
       css={[
         flex({ align: 'center', justify: 'center' }),
         typography.b2,
@@ -28,7 +28,7 @@ function ProgressText({ text }: ProgressTextProps) {
       ]}
     >
       {text[textIndex]}
-    </div>
+    </span>
   );
 }
 

--- a/frontend/src/features/loading/components/progressText/ProgressText.tsx
+++ b/frontend/src/features/loading/components/progressText/ProgressText.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { typography } from '@shared/styles/default.styled';
+import { flex, typography } from '@shared/styles/default.styled';
 
 import * as progressText from './progressText.styled';
 
@@ -20,7 +20,15 @@ function ProgressText({ text }: ProgressTextProps) {
   }, []);
 
   return (
-    <div css={[typography.b2, progressText.text()]}>{text[textIndex]}</div>
+    <div
+      css={[
+        flex({ align: 'center', justify: 'center' }),
+        typography.b2,
+        progressText.text(),
+      ]}
+    >
+      {text[textIndex]}
+    </div>
   );
 }
 

--- a/frontend/src/features/loading/components/progressText/progressText.styled.ts
+++ b/frontend/src/features/loading/components/progressText/progressText.styled.ts
@@ -3,5 +3,8 @@ import { css } from '@emotion/react';
 import { colorToken } from '@shared/styles/tokens';
 
 export const text = () => css`
+  width: 100%;
+  min-height: 24px;
+  text-align: center;
   color: ${colorToken.gray[8]};
 `;


### PR DESCRIPTION
# #️⃣ Issue Number
#373 

## 🕹️ 작업 내용

한 줄 요약 : ProgressText 컴포넌트에서 발생하는 layout shift을 해결했어요.

- [x] 가로 길이 고정 및 최소 높이 설정

## 📋 리뷰 포인트

- [ ] 로딩 화면에서 layout shift 가 발생하지 않는지 확인해주세요.

## 📸 Before/After
| Before | After |
|-----|-----|
| <img width="635" height="225" alt="스크린샷 2025-09-25 오후 3 15 37" src="https://github.com/user-attachments/assets/83a22d5d-803d-4259-b76d-bba43260070a" /> | <img width="634" height="160" alt="스크린샷 2025-09-25 오후 4 05 23" src="https://github.com/user-attachments/assets/74a76fe9-0a04-413c-846f-9514fcd5af10" /> |


## 🔮 기타 사항

- 성능 측정 환경
  - 모바일 디바이스
  - Fast 4G
  - CPU throttling: 6x slowdown
  - 클레어의 PC, 크롬 시크릿모드
- 자세한 내용은 [🔗 해결과정 분석 및 정리](https://eunsoa.notion.site/Moitz-layout-shift-279b5a1edfe480449b08c016676c9626)에서 확인가능합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - ProgressText가 컨테이너에서 가로·세로 중앙 정렬되도록 레이아웃을 개선했습니다.
  - 텍스트 영역에 width: 100%와 최소 높이 24px을 적용하고, 텍스트를 중앙 정렬했습니다.
  - 로딩 문구 내용은 동일하며, 배치 일관성과 가독성이 향상되었습니다.
  - 다양한 화면 크기에서 보다 균일한 정렬과 공간 활용이 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->