### PR TITLE
[BE] refactor: 추천 장소 NULL 방어 로직 추가

### DIFF
--- a/backend/src/main/java/com/f12/moitz/application/utils/RecommendationMapper.java
+++ b/backend/src/main/java/com/f12/moitz/application/utils/RecommendationMapper.java
@@ -56,6 +56,8 @@ public class RecommendationMapper {
     ) {
         return new Recommendation(
                 generatedPlaces.entrySet().stream()
+                        // TODO: 카테고리 키워드 재정의 혹은 네이버 장소 추천 도입 고려
+                        .filter(entry -> placeListMap.get(entry.getKey()) != null)
                         .map(place -> new Candidate(
                                 place.getKey(),
                                 placeRoutes.get(place.getKey()),


### PR DESCRIPTION
# #️⃣ Issue Number
#389 

## 🕹️ 작업 내용

- 임시로 카카오맵 추천 장소가 비어있을 경우 해당 지역 추천 X

## 🔮 기타 사항

- 추후 카테고리 키워드 재정의 혹은 네이버 장소 추천 도입 고려해야 합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 추천 생성 과정에서 연결되지 않은 장소 항목을 제외하도록 개선하여 빈/잘못된 추천이 표시되던 문제를 해결했습니다.
  - 이에 따라 추천 목록의 정확도와 일관성이 향상되었고, 예외 발생 가능성이 감소했습니다.
  - 필요 없는 항목을 사전에 걸러 처리하여 전반적인 안정성과 체감 성능이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->