### PR TITLE
[BE] refactor: 지하철 역 이름 변경

### DIFF
--- a/backend/src/main/java/com/f12/moitz/application/SubwayStationService.java
+++ b/backend/src/main/java/com/f12/moitz/application/SubwayStationService.java
@@ -33,8 +33,8 @@ public class SubwayStationService {
     }
 
     public Optional<SubwayStation> findByName(final String name) {
-        if ("이수역".equals(name)) {
-            return subwayStationRepository.findByName("총신대입구역");
+        if ("총신대입구역".equals(name) || "이수역".equals(name)) {
+            return subwayStationRepository.findByName("총신대입구(이수)역");
         }
         return subwayStationRepository.findByName(name);
     }

--- a/backend/src/main/java/com/f12/moitz/infrastructure/client/open/OpenApiClient.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/client/open/OpenApiClient.java
@@ -125,6 +125,9 @@ public class OpenApiClient {
     }
 
     private String getStationName(final String stationName) {
+        if ("총신대입구(이수)역".equals(stationName)) {
+            return "총신대입구";
+        }
         if (!"서울역".equals(stationName) && stationName.endsWith("역")) {
             return stationName.substring(0, stationName.length() - 1);
         }

--- a/backend/src/main/java/com/f12/moitz/infrastructure/client/open/dto/utils/StationResponseDeserializer.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/client/open/dto/utils/StationResponseDeserializer.java
@@ -20,7 +20,8 @@ public class StationResponseDeserializer extends JsonDeserializer<StationRespons
     );
 
     private static final Map<String, String> STATION_NAME_EXCEPTIONS = Map.of(
-            "이수", "총신대입구역",
+            "이수", "총신대입구(이수)역",
+            "총신대입구", "총신대입구(이수)역",
             "서울역", "서울역"
     );
 

--- a/backend/src/test/java/com/f12/moitz/application/SubwayStationServiceTest.java
+++ b/backend/src/test/java/com/f12/moitz/application/SubwayStationServiceTest.java
@@ -23,21 +23,24 @@ class SubwayStationServiceTest {
     @InjectMocks
     private SubwayStationService subwayStationService;
 
-    @DisplayName("'이수역'으로 지하철 역 검색 시 총신대입구역을 반환한다.")
+    @DisplayName("'이수역' 또는 '총신대입구역'으로 지하철 역 검색 시 총신대입구(이수)역을 반환한다.")
     @Test
     void convertName() {
         // Given
-        final String expectedName = "총신대입구역";
+        final String expectedName = "총신대입구(이수)역";
         final SubwayStation expectedStation = new SubwayStation(expectedName, new Point(125, 34));
 
-        Mockito.when(subwayStationRepository.findByName("총신대입구역")).thenReturn(Optional.of(expectedStation));
+        Mockito.when(subwayStationRepository.findByName("총신대입구(이수)역")).thenReturn(Optional.of(expectedStation));
 
         // When
-        final Optional<SubwayStation> station = subwayStationService.findByName("이수역");
+        final Optional<SubwayStation> station1 = subwayStationService.findByName("이수역");
+        final Optional<SubwayStation> station2 = subwayStationService.findByName("총신대입구역");
 
         // Then
-        assertThat(station).contains(expectedStation);
-        assertThat(station.get().getName()).isEqualTo(expectedName);
+        assertThat(station1).contains(expectedStation);
+        assertThat(station1.get().getName()).isEqualTo(expectedName);
+        assertThat(station2).contains(expectedStation);
+        assertThat(station2.get().getName()).isEqualTo(expectedName);
     }
 
 }


### PR DESCRIPTION
# #️⃣ Issue Number
#388 
## 🕹️ 작업 내용

한 줄 요약 : 지하철 역 이름을 일관되게 통일하여 관리 및 사용하기 위해 변경합니다. 총신대입구역 -> 총신대입구(이수)역

- [x] 지하철 역 저장 시 "총신대입구(이수)역"으로 저장
- [x] "총신대입구역" 또는 "이수역"으로 지하철 역 검색 시 "총신대입구(이수)역" 반환
- [x] 공공 API 요청 시에는 "총신대입구"로 요청하도록 변환 

## 📋 리뷰 포인트

- 지하철 역 이름 변경과 관련하여 수정되어야 할 부분이 모두 수정되었는지, 빠트린 부분은 없을지 더블체크 부탁드립니다.
- 수정된 로직에 오류가 있는 지 확인 부탁드립니다.

## 🔮 기타 사항

- LLM에 지하철 역 이름 전달 시에도 "총신대입구(이수)역"으로 통일하여 사용하기로 함.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 지하철역 명칭 정규화 개선: ‘이수역’ 또는 ‘총신대입구역’으로 검색/조회 시 ‘총신대입구(이수)역’으로 일관되게 표시·매칭됩니다.
  - 외부 API에서 ‘총신대입구(이수)역’ 수신 시 명칭 정규화 규칙 보완으로 중복/미매칭을 감소시켰습니다.
  - 검색, 결과 표시, API 응답 처리 전반에 동일 규칙을 적용해 결과 일관성이 향상됩니다.
- 테스트
  - 두 입력(‘이수역’, ‘총신대입구역’)이 동일 역으로 매칭되는 검증 케이스를 추가·수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->