### PR TITLE
[FE] fix: API 요청 오류 메세지 반영하도록 수정

### DIFF
--- a/frontend/src/shared/api/apiClient.ts
+++ b/frontend/src/shared/api/apiClient.ts
@@ -12,7 +12,7 @@ export type RequestConfig = {
 class ApiError extends Error {
   constructor(
     public status: number,
-    message?: string
+    message?: string,
   ) {
     super(message);
     this.name = 'ApiError';
@@ -23,24 +23,24 @@ export const createApiRequest = async <T>({
   endpoint,
   method = 'GET',
   body,
-  headers: customHeaders = {}
+  headers: customHeaders = {},
 }: RequestConfig): Promise<T> => {
   const url = `${BASE_URL}${endpoint}`;
 
   const headers = {
     'Content-Type': 'application/json',
-    ...customHeaders
+    ...customHeaders,
   };
 
   try {
     const response = await fetch(url, {
       method,
       headers,
-      body: body ? JSON.stringify(body) : undefined
+      body: body ? JSON.stringify(body) : undefined,
     });
 
     if (!response.ok) {
-      let errorMessage = '';
+      let errorMessage = `API 요청 실패: ${response.status} ${response.statusText}`;
 
       try {
         const errorData = await response.json();
@@ -48,7 +48,7 @@ export const createApiRequest = async <T>({
           errorMessage = errorData.message;
         }
       } catch {
-        errorMessage = `API 요청 실패: ${response.status} ${response.statusText}`;
+        // JSON 파싱 실패 시 기본 메시지 사용
       }
 
       throw new ApiError(response.status, errorMessage);
@@ -65,15 +65,25 @@ export const createApiRequest = async <T>({
 };
 
 export const apiClient = {
-  get: <T>(endpoint: string, config?: Omit<RequestConfig, 'method' | 'endpoint'>) =>
-    createApiRequest<T>({ ...config, endpoint, method: 'GET' }),
+  get: <T>(
+    endpoint: string,
+    config?: Omit<RequestConfig, 'method' | 'endpoint'>,
+  ) => createApiRequest<T>({ ...config, endpoint, method: 'GET' }),
 
-  post: <T>(endpoint: string, body?: unknown, config?: Omit<RequestConfig, 'method' | 'endpoint' | 'body'>) =>
-    createApiRequest<T>({ ...config, endpoint, method: 'POST', body }),
+  post: <T>(
+    endpoint: string,
+    body?: unknown,
+    config?: Omit<RequestConfig, 'method' | 'endpoint' | 'body'>,
+  ) => createApiRequest<T>({ ...config, endpoint, method: 'POST', body }),
 
-  put: <T>(endpoint: string, body?: unknown, config?: Omit<RequestConfig, 'method' | 'endpoint' | 'body'>) =>
-    createApiRequest<T>({ ...config, endpoint, method: 'PUT', body }),
+  put: <T>(
+    endpoint: string,
+    body?: unknown,
+    config?: Omit<RequestConfig, 'method' | 'endpoint' | 'body'>,
+  ) => createApiRequest<T>({ ...config, endpoint, method: 'PUT', body }),
 
-  delete: <T>(endpoint: string, config?: Omit<RequestConfig, 'method' | 'endpoint'>) =>
-    createApiRequest<T>({ ...config, endpoint, method: 'DELETE' })
+  delete: <T>(
+    endpoint: string,
+    config?: Omit<RequestConfig, 'method' | 'endpoint'>,
+  ) => createApiRequest<T>({ ...config, endpoint, method: 'DELETE' }),
 };

--- a/frontend/src/shared/api/apiClient.ts
+++ b/frontend/src/shared/api/apiClient.ts
@@ -12,7 +12,7 @@ export type RequestConfig = {
 class ApiError extends Error {
   constructor(
     public status: number,
-    message?: string,
+    message?: string
   ) {
     super(message);
     this.name = 'ApiError';
@@ -23,24 +23,24 @@ export const createApiRequest = async <T>({
   endpoint,
   method = 'GET',
   body,
-  headers: customHeaders = {},
+  headers: customHeaders = {}
 }: RequestConfig): Promise<T> => {
   const url = `${BASE_URL}${endpoint}`;
 
   const headers = {
     'Content-Type': 'application/json',
-    ...customHeaders,
+    ...customHeaders
   };
 
   try {
     const response = await fetch(url, {
       method,
       headers,
-      body: body ? JSON.stringify(body) : undefined,
+      body: body ? JSON.stringify(body) : undefined
     });
 
     if (!response.ok) {
-      let errorMessage = `API 요청 실패: ${response.status} ${response.statusText}`;
+      let errorMessage = '';
 
       try {
         const errorData = await response.json();
@@ -48,7 +48,7 @@ export const createApiRequest = async <T>({
           errorMessage = errorData.message;
         }
       } catch {
-        // JSON 파싱 실패 시 기본 메시지 사용
+        errorMessage = `API 요청 실패: ${response.status} ${response.statusText}`;
       }
 
       throw new ApiError(response.status, errorMessage);
@@ -65,25 +65,15 @@ export const createApiRequest = async <T>({
 };
 
 export const apiClient = {
-  get: <T>(
-    endpoint: string,
-    config?: Omit<RequestConfig, 'method' | 'endpoint'>,
-  ) => createApiRequest<T>({ ...config, endpoint, method: 'GET' }),
+  get: <T>(endpoint: string, config?: Omit<RequestConfig, 'method' | 'endpoint'>) =>
+    createApiRequest<T>({ ...config, endpoint, method: 'GET' }),
 
-  post: <T>(
-    endpoint: string,
-    body?: unknown,
-    config?: Omit<RequestConfig, 'method' | 'endpoint' | 'body'>,
-  ) => createApiRequest<T>({ ...config, endpoint, method: 'POST', body }),
+  post: <T>(endpoint: string, body?: unknown, config?: Omit<RequestConfig, 'method' | 'endpoint' | 'body'>) =>
+    createApiRequest<T>({ ...config, endpoint, method: 'POST', body }),
 
-  put: <T>(
-    endpoint: string,
-    body?: unknown,
-    config?: Omit<RequestConfig, 'method' | 'endpoint' | 'body'>,
-  ) => createApiRequest<T>({ ...config, endpoint, method: 'PUT', body }),
+  put: <T>(endpoint: string, body?: unknown, config?: Omit<RequestConfig, 'method' | 'endpoint' | 'body'>) =>
+    createApiRequest<T>({ ...config, endpoint, method: 'PUT', body }),
 
-  delete: <T>(
-    endpoint: string,
-    config?: Omit<RequestConfig, 'method' | 'endpoint'>,
-  ) => createApiRequest<T>({ ...config, endpoint, method: 'DELETE' }),
+  delete: <T>(endpoint: string, config?: Omit<RequestConfig, 'method' | 'endpoint'>) =>
+    createApiRequest<T>({ ...config, endpoint, method: 'DELETE' })
 };

--- a/frontend/src/shared/api/apiClient.ts
+++ b/frontend/src/shared/api/apiClient.ts
@@ -40,15 +40,15 @@ export const createApiRequest = async <T>({
     });
 
     if (!response.ok) {
-      let errorMessage = '';
+      let errorMessage = `API 요청 실패: ${response.status} ${response.statusText}`;
 
       try {
         const errorData = await response.json();
-        if (errorData.message) {
+        if (errorData?.message && typeof errorData.message === 'string') {
           errorMessage = errorData.message;
         }
       } catch {
-        errorMessage = `API 요청 실패: ${response.status} ${response.statusText}`;
+        // JSON 파싱 실패 무시
       }
 
       throw new ApiError(response.status, errorMessage);
@@ -60,7 +60,10 @@ export const createApiRequest = async <T>({
     if (error instanceof ApiError) {
       throw error;
     }
-    throw new ApiError(error.status || 500, error.message);
+
+    const errorMessage =
+      error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다';
+    throw new ApiError(500, errorMessage);
   }
 };
 

--- a/frontend/src/shared/api/apiClient.ts
+++ b/frontend/src/shared/api/apiClient.ts
@@ -12,7 +12,7 @@ export type RequestConfig = {
 class ApiError extends Error {
   constructor(
     public status: number,
-    message?: string,
+    message?: string
   ) {
     super(message);
     this.name = 'ApiError';
@@ -23,27 +23,35 @@ export const createApiRequest = async <T>({
   endpoint,
   method = 'GET',
   body,
-  headers: customHeaders = {},
+  headers: customHeaders = {}
 }: RequestConfig): Promise<T> => {
   const url = `${BASE_URL}${endpoint}`;
 
   const headers = {
     'Content-Type': 'application/json',
-    ...customHeaders,
+    ...customHeaders
   };
 
   try {
     const response = await fetch(url, {
       method,
       headers,
-      body: body ? JSON.stringify(body) : undefined,
+      body: body ? JSON.stringify(body) : undefined
     });
 
     if (!response.ok) {
-      throw new ApiError(
-        response.status,
-        `API 요청 실패: ${response.status} ${response.statusText}`,
-      );
+      let errorMessage = '';
+
+      try {
+        const errorData = await response.json();
+        if (errorData.message) {
+          errorMessage = errorData.message;
+        }
+      } catch {
+        errorMessage = `API 요청 실패: ${response.status} ${response.statusText}`;
+      }
+
+      throw new ApiError(response.status, errorMessage);
     }
 
     const data = await response.json();
@@ -52,30 +60,20 @@ export const createApiRequest = async <T>({
     if (error instanceof ApiError) {
       throw error;
     }
-    throw new ApiError(error.status, error.message);
+    throw new ApiError(error.status || 500, error.message);
   }
 };
 
 export const apiClient = {
-  get: <T>(
-    endpoint: string,
-    config?: Omit<RequestConfig, 'method' | 'endpoint'>,
-  ) => createApiRequest<T>({ ...config, endpoint, method: 'GET' }),
+  get: <T>(endpoint: string, config?: Omit<RequestConfig, 'method' | 'endpoint'>) =>
+    createApiRequest<T>({ ...config, endpoint, method: 'GET' }),
 
-  post: <T>(
-    endpoint: string,
-    body?: unknown,
-    config?: Omit<RequestConfig, 'method' | 'endpoint' | 'body'>,
-  ) => createApiRequest<T>({ ...config, endpoint, method: 'POST', body }),
+  post: <T>(endpoint: string, body?: unknown, config?: Omit<RequestConfig, 'method' | 'endpoint' | 'body'>) =>
+    createApiRequest<T>({ ...config, endpoint, method: 'POST', body }),
 
-  put: <T>(
-    endpoint: string,
-    body?: unknown,
-    config?: Omit<RequestConfig, 'method' | 'endpoint' | 'body'>,
-  ) => createApiRequest<T>({ ...config, endpoint, method: 'PUT', body }),
+  put: <T>(endpoint: string, body?: unknown, config?: Omit<RequestConfig, 'method' | 'endpoint' | 'body'>) =>
+    createApiRequest<T>({ ...config, endpoint, method: 'PUT', body }),
 
-  delete: <T>(
-    endpoint: string,
-    config?: Omit<RequestConfig, 'method' | 'endpoint'>,
-  ) => createApiRequest<T>({ ...config, endpoint, method: 'DELETE' }),
+  delete: <T>(endpoint: string, config?: Omit<RequestConfig, 'method' | 'endpoint'>) =>
+    createApiRequest<T>({ ...config, endpoint, method: 'DELETE' })
 };

--- a/frontend/src/shared/api/apiClient.ts
+++ b/frontend/src/shared/api/apiClient.ts
@@ -12,7 +12,7 @@ export type RequestConfig = {
 class ApiError extends Error {
   constructor(
     public status: number,
-    message?: string
+    message?: string,
   ) {
     super(message);
     this.name = 'ApiError';
@@ -23,20 +23,20 @@ export const createApiRequest = async <T>({
   endpoint,
   method = 'GET',
   body,
-  headers: customHeaders = {}
+  headers: customHeaders = {},
 }: RequestConfig): Promise<T> => {
   const url = `${BASE_URL}${endpoint}`;
 
   const headers = {
     'Content-Type': 'application/json',
-    ...customHeaders
+    ...customHeaders,
   };
 
   try {
     const response = await fetch(url, {
       method,
       headers,
-      body: body ? JSON.stringify(body) : undefined
+      body: body ? JSON.stringify(body) : undefined,
     });
 
     if (!response.ok) {
@@ -68,15 +68,25 @@ export const createApiRequest = async <T>({
 };
 
 export const apiClient = {
-  get: <T>(endpoint: string, config?: Omit<RequestConfig, 'method' | 'endpoint'>) =>
-    createApiRequest<T>({ ...config, endpoint, method: 'GET' }),
+  get: <T>(
+    endpoint: string,
+    config?: Omit<RequestConfig, 'method' | 'endpoint'>,
+  ) => createApiRequest<T>({ ...config, endpoint, method: 'GET' }),
 
-  post: <T>(endpoint: string, body?: unknown, config?: Omit<RequestConfig, 'method' | 'endpoint' | 'body'>) =>
-    createApiRequest<T>({ ...config, endpoint, method: 'POST', body }),
+  post: <T>(
+    endpoint: string,
+    body?: unknown,
+    config?: Omit<RequestConfig, 'method' | 'endpoint' | 'body'>,
+  ) => createApiRequest<T>({ ...config, endpoint, method: 'POST', body }),
 
-  put: <T>(endpoint: string, body?: unknown, config?: Omit<RequestConfig, 'method' | 'endpoint' | 'body'>) =>
-    createApiRequest<T>({ ...config, endpoint, method: 'PUT', body }),
+  put: <T>(
+    endpoint: string,
+    body?: unknown,
+    config?: Omit<RequestConfig, 'method' | 'endpoint' | 'body'>,
+  ) => createApiRequest<T>({ ...config, endpoint, method: 'PUT', body }),
 
-  delete: <T>(endpoint: string, config?: Omit<RequestConfig, 'method' | 'endpoint'>) =>
-    createApiRequest<T>({ ...config, endpoint, method: 'DELETE' })
+  delete: <T>(
+    endpoint: string,
+    config?: Omit<RequestConfig, 'method' | 'endpoint'>,
+  ) => createApiRequest<T>({ ...config, endpoint, method: 'DELETE' }),
 };


### PR DESCRIPTION
# #️⃣ Issue Number
#393 

## 🕹️ 작업 내용

배경 :  에러 메세지를 저장하지 않고 있어요 && FallbackPage의 UI에서 에러 메세지가 보이지 않았어요
한 줄 요약 : API 요청 실패 시, 서버에서 반환된 오류 메시지를 사용하도록 수정했어요

- [ ] apiClient 에서 errorMessage를 설정

## 📸 Before / After
404에러가 발생했을때 뜨는 FallbackPage 의 UI를 예시로 가져왔어요
| Before | After |
|---|---|
| <img width="346" height="748" alt="스크린샷 2025-09-25 오후 6 41 49" src="https://github.com/user-attachments/assets/80fcd5e8-0fcf-4fbf-9330-3cb6a2aa2793" /> | <img width="346" height="753" alt="스크린샷 2025-09-25 오후 6 39 27" src="https://github.com/user-attachments/assets/6dac1386-7e55-44f1-8723-11684e756100" /> |

## 📋 리뷰 포인트

- [ ] fallbackPage에서 에러 메세지가 정상적으로 api 에러 메세지와 동일하게 보이는지 확인해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 없음

- 버그 수정
  - API 요청 실패 시 더 구체적이고 일관된 오류 메시지를 제공하여 사용자 이해도를 향상했습니다.
  - 예기치 않은 오류도 적절한 상태 코드와 메시지로 처리되어 빈 메시지 또는 모호한 실패 문구가 표시되던 문제를 개선했습니다.

- 리팩터링
  - 내부 오류 처리 흐름을 단순화해 신뢰성과 일관성을 높였으며, 공개된 사용 방식은 변경되지 않았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->