### PR TITLE
[FE] refactor: 최적화 성능 개선

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -49,6 +49,7 @@
       gtag('config', 'G-59F40P3XW8');
     </script>
 
+    <!-- Main App -->
     <script type="module" src="main.tsx"></script>
   </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -49,7 +49,6 @@
       gtag('config', 'G-59F40P3XW8');
     </script>
 
-    <!-- Main App -->
     <script type="module" src="main.tsx"></script>
   </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,37 +1,35 @@
 <!doctype html>
 <html lang="ko">
-  <head>
-    <!-- 문서 기본 -->
-    <meta charset="UTF-8" />
-    <title>모잇지</title>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  
-    <!-- SEO 기본 -->
-    <meta name="description" content="사람들의 위치를 바탕으로 취향·목적·거리를 고려해 약속 장소를 추천해 드리는 서비스, 모잇지!" />
-    <meta name="robots" content="index,follow" />
-    <link rel="canonical" href="https://moitz.kr/" />
-  
-    <!-- 소셜 공유 (Open Graph / Twitter) -->
-    <meta property="og:locale" content="ko_KR" />
-    <meta property="og:site_name" content="모잇지" />
-    <meta property="og:type" content="website" />
-    <meta property="og:title" content="친구들과 모임, 만날 지역을 빠르게! 모잇지!" />
-    <meta property="og:description" content="매번 약속 장소 정하기가 피곤하다면? 위치 기반으로 취향·목적·거리를 고려해 최적의 약속 장소를 추천해 드려요." />
-    <meta property="og:image" content="" />
-    <meta property="og:url" content="https://moitz.kr/" />
-    <meta name="twitter:card" content="" />
-  
-    <!-- 아이콘 -->
-    <link rel="icon" type="image/svg+xml" href="assets/icon/logo-icon.svg" />
-  
-    <!-- 성능: 외부 도메인 사전연결 -->
-    <link rel="preconnect" href="https://oapi.map.naver.com" crossorigin />
-    <link rel="dns-prefetch" href="https://oapi.map.naver.com" />
-    <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
-    <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
-  </head>
-    
+    <head>
+      <!-- 문서 기본 -->
+      <meta charset="UTF-8" />
+      <title>모잇지</title>
+      <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <meta http-equiv="Cache-Control" content="no-store" />
+
+      <!-- SEO 기본 -->
+      <meta name="description" content="사람들의 위치를 바탕으로 취향·목적·거리를 고려해 약속 장소를 추천해 드리는 서비스, 모잇지!" />
+      <meta name="robots" content="index,follow" />
+      <link rel="canonical" href="https://moitz.kr/" />
+
+      <!-- 소셜 공유 (Open Graph / Twitter) -->
+      <meta property="og:locale" content="ko_KR" />
+      <meta property="og:site_name" content="모잇지" />
+      <meta property="og:type" content="website" />
+      <meta property="og:title" content="친구들과 모임, 만날 지역을 빠르게! 모잇지!" />
+      <meta property="og:description" content="매번 약속 장소 정하기가 피곤하다면? 위치 기반으로 취향·목적·거리를 고려해 최적의 약속 장소를 추천해 드려요." />
+      <meta property="og:image" content="" />
+      <meta property="og:url" content="https://moitz.kr/" />
+      <meta name="twitter:card" content="" />
+
+      <!-- 성능: 외부 도메인 사전연결 -->
+      <link rel="preconnect" href="https://oapi.map.naver.com" crossorigin />
+      <link rel="dns-prefetch" href="https://oapi.map.naver.com" />
+      <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
+      <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
+    </head>
+
   <body>
     <div id="root"></div>
     <!-- Naver Map API -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -48,8 +48,5 @@
       gtag('js', new Date());
       gtag('config', 'G-59F40P3XW8');
     </script>
-
-    <!-- Main App -->
-    <script type="module" src="main.tsx"></script>
   </body>
 </html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -58,6 +58,7 @@
         "typescript-eslint": "^8.36.0",
         "web-streams-polyfill": "^4.1.0",
         "webpack": "^5.100.0",
+        "webpack-bundle-analyzer": "^4.10.2",
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.2",
         "whatwg-fetch": "^3.6.20"
@@ -3478,6 +3479,13 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
     },
@@ -7578,6 +7586,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -7951,6 +7966,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -9787,6 +9809,22 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/handle-thing": {
@@ -13096,6 +13134,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -13523,6 +13571,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -15218,6 +15276,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -15943,6 +16016,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tough-cookie": {
@@ -16718,6 +16801,75 @@
       },
       "peerDependenciesMeta": {
         "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.2.tgz",
+      "integrity": "sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,6 +64,7 @@
     "typescript-eslint": "^8.36.0",
     "web-streams-polyfill": "^4.1.0",
     "webpack": "^5.100.0",
+    "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.2",
     "whatwg-fetch": "^3.6.20"

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -55,7 +55,7 @@ export default function common(envVars = {}) {
       new HtmlWebpackPlugin({
         template: 'index.html',
         templateParameters: envVars,
-        favicon: './assets/icon/logo-icon.svg',
+        favicon: path.resolve(__dirname, './assets/icon/logo-icon.svg'),
       }),
     ],
   };

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -29,7 +29,7 @@ export default merge(common(envVars), {
     hot: true,
   },
   output: {
-    filename: '[name].[contenthash].js',
+    filename: '[name].js',
     assetModuleFilename: 'assets/[hash][ext][query]',
     clean: true,
   },

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -2,6 +2,7 @@ import dotenv from 'dotenv';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
 import webpack from 'webpack';
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import { merge } from 'webpack-merge';
 
 import common from './webpack.common.js';
@@ -41,6 +42,7 @@ export default merge(common(envVars), {
     new MiniCssExtractPlugin({
       filename: '[name].[contenthash].css',
     }),
+    new BundleAnalyzerPlugin(),
   ],
   optimization: {
     minimize: true,
@@ -58,3 +60,4 @@ export default merge(common(envVars), {
     runtimeChunk: 'single',
   },
 });
+

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -27,6 +27,7 @@ export default merge(common(envVars), {
   output: {
     filename: '[name].[contenthash].js',
     assetModuleFilename: 'assets/[hash][ext][query]',
+    publicPath: '/',
     clean: true,
   },
   module: {
@@ -34,6 +35,13 @@ export default merge(common(envVars), {
       {
         test: /\.css$/i,
         use: [MiniCssExtractPlugin.loader, 'css-loader'],
+      },
+      {
+        test: /\.svg$/i,
+        type: 'asset/resource',
+        generator: {
+          filename: 'assets/[name].[contenthash][ext]',
+        },
       },
     ],
   },
@@ -59,5 +67,7 @@ export default merge(common(envVars), {
     splitChunks: { chunks: 'all' },
     runtimeChunk: 'single',
   },
+  performance: {
+    hints: false,
+  },
 });
-

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -2,7 +2,7 @@ import dotenv from 'dotenv';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
 import webpack from 'webpack';
-import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
+// import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import { merge } from 'webpack-merge';
 
 import common from './webpack.common.js';
@@ -50,7 +50,7 @@ export default merge(common(envVars), {
     new MiniCssExtractPlugin({
       filename: '[name].[contenthash].css',
     }),
-    new BundleAnalyzerPlugin(),
+    // new BundleAnalyzerPlugin(),
   ],
   optimization: {
     minimize: true,


### PR DESCRIPTION
#️⃣ Issue Number

#380 

# 👀 환경

- 사이트: https://moitz.kr/
- 위치: Paris
- 네트워크: 3G Fast
- [검사 결과 링크](https://www.webpagetest.org/result/250925_ZiDc3V_1WS/)

# 👎 개선 전 성능 측정 결과

## 1) IndexPage

<img width="1317" height="624" alt="Image" src="https://github.com/user-attachments/assets/267da44f-6155-45ab-9534-d63e6a58fa7a" />
<img width="718" height="702" alt="Image" src="https://github.com/user-attachments/assets/f1d24494-4ea6-4fb3-801c-6cd0f6e53a7f" />

## 2) ResultPage

<img width="715" height="700" alt="Image" src="https://github.com/user-attachments/assets/49f3ea06-c5a2-401e-86e7-58f4e05eb1e8" />

# 👍 개선 후 성능 측정 결과 

## 1) IndexPage

<img width="847" height="615" alt="Image" src="https://github.com/user-attachments/assets/b08a43fe-24f2-4148-9664-fc954d1b9e63" />
<img width="1303" height="554" alt="Image" src="https://github.com/user-attachments/assets/63189fb8-af61-4175-aae8-064f4056f0ff" />

## 2) ResultPage


<img width="670" height="659" alt="Image" src="https://github.com/user-attachments/assets/4ab2e626-a7c4-40ac-89e9-2dea33a1ce83" />

# ✅ 개선 작업 목록

## 목표

- [ ] Lighthouse performance 95점 이상
- [ ] 프랑스 파리에서 Fast 3G 환경으로 접속했을 때
  - [ ] 메인 페이지 첫 번째 로드시 LCP < 2.5s
  - [ ] 메인 페이지 두 번째 이후 로드시 LCP < 1.5s

네이버 API 성능 최적화 로직을 적용하면, 모두 기준에 도달할 것으로 보입니다.
LightHouse에서 네이버 API 외에 더 이상 개선할 로직이 없었습니다 🙌

## 작업 목록

1. 소스코드 크기 줄이기
  - [x] 코드 압축/분리(code split 을 통해 bundle 사이즈를 줄이기) → 요청 크기 감소
  - [x] webpack-bundle-analyze 설치 
  - [x] unused javascript를 줄이기( minify / uglify javascript)
2. CloudFront / S3 캐시 설정캐시 정책:
  - [x] index.html → no-store (항상 최신)
  - [x] JS/CSS/에셋 → 1년 캐시 (immutable)

## 그 외

아래 부분에 대해서는 더 자세히 노션으로 작성할게요~ 일단 간단하게 적어봤어용

- [x]  버그 수정: index.html 잘못된 <script> 제거
→ index.html에서 main.tsx을 직접 불러오던 태그 삭제, HtmlWebpackPlugin이 번들 JS 자동 주입
- [x] entry 경로 수정
→ Webpack entry를 ./main.tsx → ./src/main.tsx로 수정해 실제 소스와 일치
- [x] 브라우저 캐싱으로 인해 S3 배포 버전이 화면에 그려지지 않는 문제 해결
→ `<meta http-equiv="Cache-Control" content="no-store" />`