### PR TITLE
[BE] feat: 서킷브레이커 적용

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 	implementation 'io.micrometer:micrometer-registry-cloudwatch2'
 
+	implementation 'io.github.resilience4j:resilience4j-all:2.2.0'
+	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 	implementation 'io.micrometer:micrometer-registry-cloudwatch2'
 
+	implementation 'io.github.resilience4j:resilience4j-micrometer'
 	implementation 'io.github.resilience4j:resilience4j-all:2.2.0'
 	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
 

--- a/backend/src/main/java/com/f12/moitz/common/config/MonitoringConfig.java
+++ b/backend/src/main/java/com/f12/moitz/common/config/MonitoringConfig.java
@@ -55,11 +55,12 @@ public class MonitoringConfig {
         return MeterFilter.denyUnless(id -> {
             String uri = id.getTag("uri");
             return id.getName().startsWith("http.server.requests") &&
-                    uri != null && !uri.contains("swagger") && !uri.contains("api-docs")
-                    || id.getName().startsWith("executor.completed") || id.getName().startsWith("executor.queued")
-                    || id.getName().startsWith("jvm.threads")
-                    || id.getName().startsWith("jvm.memory.used")
-                    || id.getName().startsWith("process");
+                   uri != null && !uri.contains("swagger") && !uri.contains("api-docs")
+                   || id.getName().startsWith("resilience4j.circuitbreaker.")
+                   || id.getName().startsWith("executor.completed") || id.getName().startsWith("executor.queued")
+                   || id.getName().startsWith("jvm.threads")
+                   || id.getName().startsWith("jvm.memory.used")
+                   || id.getName().startsWith("process");
         });
     }
 

--- a/backend/src/main/java/com/f12/moitz/common/config/ResilienceConfig.java
+++ b/backend/src/main/java/com/f12/moitz/common/config/ResilienceConfig.java
@@ -1,0 +1,29 @@
+package com.f12.moitz.common.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class ResilienceConfig {
+
+    private final CircuitBreakerRegistry registry;
+
+    @Bean
+    public CircuitBreaker geminiBreaker() {
+        final CircuitBreaker circuitBreaker = registry.circuitBreaker("gemini");
+        circuitBreaker.getEventPublisher();
+        return circuitBreaker;
+    }
+
+    @Bean
+    public CircuitBreaker geminiRetryableBreaker() {
+        final CircuitBreaker circuitBreaker = registry.circuitBreaker("geminiRetryable");
+        circuitBreaker.getEventPublisher();
+        return circuitBreaker;
+    }
+
+}

--- a/backend/src/main/java/com/f12/moitz/infrastructure/adapter/LocationRecommenderAdapter.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/adapter/LocationRecommenderAdapter.java
@@ -2,10 +2,15 @@ package com.f12.moitz.infrastructure.adapter;
 
 import com.f12.moitz.application.dto.RecommendedLocationsResponse;
 import com.f12.moitz.application.port.LocationRecommender;
+import com.f12.moitz.common.error.exception.ExternalApiException;
 import com.f12.moitz.common.error.exception.RetryableApiException;
 import com.f12.moitz.infrastructure.client.gemini.GoogleGeminiClient;
 import com.f12.moitz.infrastructure.client.perplexity.PerplexityClient;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.decorators.Decorators;
 import java.util.List;
+import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.retry.annotation.Recover;
@@ -16,9 +21,11 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class LocationRecommenderAdapter implements LocationRecommender {
-    private final GoogleGeminiClient geminiClient;
 
+    private final GoogleGeminiClient geminiClient;
     private final PerplexityClient perplexityClient;
+    private final CircuitBreaker geminiBreaker;
+    private final CircuitBreaker geminiRetryableBreaker;
 
     @Retryable(
             retryFor = RetryableApiException.class,
@@ -31,17 +38,34 @@ public class LocationRecommenderAdapter implements LocationRecommender {
             final List<String> candidatePlaces,
             final String requirement
     ) {
-        final RecommendedLocationsResponse generatedResponse = geminiClient.generateResponse(
+        final Supplier<RecommendedLocationsResponse> geminiCall = () -> geminiClient.generateResponse(
                 startingPlaces,
                 candidatePlaces,
                 requirement
         );
+
+        final Supplier<RecommendedLocationsResponse> decoratedGeminiCall = Decorators.ofSupplier(geminiCall)
+                .withCircuitBreaker(geminiBreaker)
+                .withCircuitBreaker(geminiRetryableBreaker)
+                .withFallback(
+                        List.of(ExternalApiException.class, CallNotPermittedException.class),
+                        throwable -> fallback(startingPlaces, requirement)
+                )
+                .decorate();
+
+        final RecommendedLocationsResponse generatedResponse = decoratedGeminiCall.get();
+
         final RecommendedLocationsResponse deduplicatedLocations = deduplicateLocation(generatedResponse);
 
         return excludeStartPlaces(
                 deduplicatedLocations,
                 startingPlaces
         );
+    }
+
+    private RecommendedLocationsResponse fallback(final List<String> startingPlaces, final String requirement) {
+        log.debug("FallBack: Perplexity 호출을 시도합니다.");
+        return perplexityClient.generateResponse(startingPlaces, requirement);
     }
 
     @Recover

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -33,3 +33,21 @@ spring.data.mongodb.min-heartbeat-frequency=10000
 
 spring.data.mongodb.read-preference=primaryPreferred
 spring.data.mongodb.read-concern=local
+
+resilience4j.circuitbreaker.configs.default.slidingWindowType=COUNT_BASED
+resilience4j.circuitbreaker.configs.default.slidingWindowSize=5
+resilience4j.circuitbreaker.configs.default.failureRateThreshold=60
+resilience4j.circuitbreaker.configs.default.waitDurationInOpenState=30s
+resilience4j.circuitbreaker.configs.default.permittedNumberOfCallsInHalfOpenState=2
+resilience4j.circuitbreaker.configs.default.minimumNumberOfCalls=5
+
+resilience4j.circuitbreaker.instances.gemini.baseConfig=default
+resilience4j.circuitbreaker.instances.gemini.slidingWindowSize=1
+resilience4j.circuitbreaker.instances.gemini.failureRateThreshold=50
+resilience4j.circuitbreaker.instances.gemini.minimumNumberOfCalls=1
+resilience4j.circuitbreaker.instances.gemini.recordExceptions=com.f12.moitz.common.error.exception.ExternalApiException
+resilience4j.circuitbreaker.instances.gemini.ignoreExceptions=com.f12.moitz.common.error.exception.RetryableApiException
+
+resilience4j.circuitbreaker.instances.geminiRetryable.baseConfig=default
+resilience4j.circuitbreaker.instances.geminiRetryable.recordExceptions=com.f12.moitz.common.error.exception.RetryableApiException
+resilience4j.circuitbreaker.instances.geminiRetryable.ignoreExceptions=com.f12.moitz.common.error.exception.ExternalApiException,io.github.resilience4j.circuitbreaker.CallNotPermittedException

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -13,8 +13,17 @@ logging.file.warn.path=./logs/warn
 logging.file.error.path=./logs/error
 
 management.endpoints.web.base-path=/
+management.endpoints.web.exposure.include=health,metrics
 management.endpoints.enabled-by-default=false
 management.endpoint.health.enabled=true
+management.endpoint.metrics.enabled=true
+
+management.metrics.export.cloudwatch.enabled=true
+management.metrics.export.cloudwatch.namespace=Moitz2025Dev
+management.metrics.export.cloudwatch.step=30s
+management.metrics.export.cloudwatch.region=ap-northeast-2
+management.metrics.tags.app=moitz
+management.metrics.tags.env=dev
 
 spring.data.mongodb.auto-index-creation=true
 


### PR DESCRIPTION
# #️⃣ Issue Number
#396 
## 🕹️ 작업 내용

한 줄 요약 : Gemini API 호출에 대해 서킷브레이커를 적용합니다.

- [x] 서킷브레이커 적용
- [x] 서킷브레이커 지표 수집하여 CloudWatch로 전송

## 📋 리뷰 포인트

- 오타가 없는지 확인 부탁드립니다.

## 🔮 기타 사항

- 실패율이 높아져 서킷브레이커가 OPEN 상태가 되면 fallback() 메서드를 호출해 Perplexity에 요청을 보내는데, Perplexity 쪽에는 아직 후보지 제공 로직이 적용되지 않은 상태입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 위치 추천 요청에서 기본 AI 실패 시 대체 제공자로 자동 폴백, 안정성 향상
  - 회로 차단 기반의 복원력 적용으로 오류/지연 시 빠른 복구와 사용자 체감 가용성 개선

- 작업
  - 복원력 관련 라이브러리 및 애플리케이션 설정 추가
  - 헬스·메트릭스 엔드포인트 활성화 및 CloudWatch 메트릭스 연동, 모니터링 필터 확장
  - 데이터베이스 연결/풀 파라미터 튜닝으로 연결 안정성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->