### PR TITLE
[FE] fix: ESLint indent 규칙과 Prettier 간의 들여쓰기 충돌 해결

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -61,7 +61,6 @@ export default [
 
       // emotion css prop를 쓰기 위한 규칙
       'react/no-unknown-property': ['error', { ignore: ['css'] }],
-      indent: ['error', 2],
       'import/order': [
         'error',
         {
@@ -136,7 +135,7 @@ export default [
             {
               pattern: '@sb/**',
               group: 'internal',
-              position: 'before'
+              position: 'before',
             },
           ],
           pathGroupsExcludedImportTypes: ['react'],


### PR DESCRIPTION
# #️⃣ Issue Number
#402 

## 🕹️ 작업 내용

한 줄 요약 : ESLint indent 규칙과 Prettier 간의 들여쓰기 충돌 해결

- [x] ESLint의 `indent: ['error', 2]` 규칙 비활성화
- [x] Prettier가 들여쓰기 포맷팅을 전담하도록 설정 변경

## 📋 리뷰 포인트

- ESLint와 Prettier가 서로 다른 방식으로 들여쓰기를 처리하여 충돌 발생
- ESLint는 문법적 들여쓰기 규칙, Prettier는 시각적 포맷팅을 담당하는 것이 베스트 프랙티스
- `eslint.config.mjs`에서 indent 규칙만 주석 처리하여 최소한의 변경으로 해결

## 🔮 기타 사항

- 코드 포맷팅은 Prettier가 일관되게 처리하므로 향후 들여쓰기 관련 린트 에러 방지
- ESLint는 코드 품질 검사에만 집중하게 되어 역할 분리 명확화


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신뢰성/유지보수(Chores)
  - 린트 설정을 간소화하여 들여쓰기 강제 규칙을 제거, 불필요한 경고를 줄였습니다.
  - 개발자 경험을 개선해 코드 리뷰 마찰을 완화했습니다.
- 스타일(Style)
  - 구성 포맷을 일관되게 정리해 설정 가독성을 향상했습니다.

참고: 사용자 기능 변화는 없습니다. 실행/빌드 동작에 영향이 없으며, 기존 기능은 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->