### PR TITLE
[FE] fix: mapPoint 스토리북 깨짐 수정

### DIFF
--- a/frontend/src/shared/components/mapPoint/mapPoint.stories.ts
+++ b/frontend/src/shared/components/mapPoint/mapPoint.stories.ts
@@ -1,9 +1,12 @@
+import { withContainer } from '@sb/decorators/withContainer';
+
 import MapPoint from './MapPoint';
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
   component: MapPoint,
+  decorators: [withContainer],
   parameters: {
     layout: 'centered',
   },


### PR DESCRIPTION
# #️⃣ Issue Number
#422 

## 🕹️ 작업 내용

한 줄 요약 : MapPoint 스토리북에 container decorator 추가하여 깨짐을 해결했어요

| Before | After |
|------|-----|
|<img width="1051" height="356" alt="스크린샷 2025-10-09 오후 7 58 52" src="https://github.com/user-attachments/assets/e2fda662-98ee-4804-8150-745c99bdc776" /> | <img width="1059" height="362" alt="스크린샷 2025-10-09 오후 7 59 06" src="https://github.com/user-attachments/assets/d0a15eb7-df45-4c03-b1ba-3809da6e6c15" /> |


## 📋 리뷰 포인트

- [ ] 스토리북에서 정상적으로 보여지는지 확인해주세요

## 🔮 기타 사항

- 투표하기 버튼을 구현하던 과정에서 발견하여, 이슈에 추가하고 테스크를 분리하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 문서화
  - Storybook에서 MapPoint 컴포넌트에 컨테이너 데코레이터를 적용해 미리보기가 실제 사용 환경과 더 유사하게 표시됩니다.
  - 레이아웃·간격이 일관되게 렌더링되어 시각적 검토와 스냅샷 확인이 쉬워지고, 다양한 화면 크기에서의 동작 확인과 디자인 리뷰의 정확성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->