### PR TITLE
[FE] fix: 사파리에서 바텀시트 스크롤이 넘어가는 이슈 해결

### DIFF
--- a/frontend/src/features/recommendation/components/bottomSheetView/bottomSheetView.styled.ts
+++ b/frontend/src/features/recommendation/components/bottomSheetView/bottomSheetView.styled.ts
@@ -19,9 +19,9 @@ export const container = (positionPercent: number) => css`
     margin: auto;
   }
 
-  height: ${MIN_VH + (MAX_VH - MIN_VH) * (positionPercent / 100)}vh;
-  min-height: ${MIN_VH}vh;
-  max-height: ${MAX_VH}vh;
+  height: ${MIN_VH + (MAX_VH - MIN_VH) * (positionPercent / 100)}dvh;
+  min-height: ${MIN_VH}dvh;
+  max-height: ${MAX_VH}dvh;
 
   padding: 0px 20px;
   background-color: ${colorToken.gray[8]};


### PR DESCRIPTION
# #️⃣ Issue Number
#423 

## 🕹️ 작업 내용

배경 : 사파리 모바일 환경에서 바텀 시트 높이 90의 경우, 헤더까지 올라가서 스크롤이 내려오지 못하는 이슈가 있었어요
한 줄 요약 : bottomSheetView 의 높이 속성을 vh에서 dvh로 변경하여 모바일에서 정상적으로 동작하도록 수정했어요

| Before | After |
|------|-----|
|![ScreenRecording_10-09-2025 21-37-06_1](https://github.com/user-attachments/assets/62c3b2a7-bf02-4142-b632-6ac47c873be8) | ![ScreenRecording_10-09-2025 21-38-04_1](https://github.com/user-attachments/assets/63fcf519-2724-4a02-bb75-97b925b346ec) | 

## 📋 리뷰 포인트

- [ ] 모바일, 데스크탑 환경에서 정상적으로 동작하는지 확인해주세요.
- [ ] 사파리, 크롬 환경에서 모두 정상적으로 동작하는지 확인해주세요.

## 🔮 기타 사항

- 투표하기 버튼을 구현하던 과정에서 발견하여, 이슈에 추가하고 테스크를 분리하였습니다.
- vh 단위 관련한 자세한 내용은 [문서](https://eunsoa.notion.site/css-dvh-svh-lvh-287b5a1edfe4807aa3acdc1a979cd01b?source=copy_link)에서 정리했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 모바일에서 브라우저 UI(주소창 등) 표시/숨김 시 바텀시트가 화면을 벗어나거나 빈 공간이 생기던 현상을 줄였습니다. 실제 표시 영역에 맞춰 높이가 즉시 반영되어 스크롤과 제스처 사용이 더 안정적입니다.
* **Style**
  * 컨테이너의 height/min/max 계산을 동적 뷰포트 기준으로 업데이트했습니다. 다양한 기기와 가로/세로 전환, PWA/전체화면 환경에서도 레이아웃 일관성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->