### PR TITLE
[BE] chore: CI/CD 스크립트 수정

### DIFF
--- a/.github/workflows/be-cicd-dev-auto-trigger.yml
+++ b/.github/workflows/be-cicd-dev-auto-trigger.yml
@@ -3,45 +3,55 @@ name: Backend 개발 서버 CI/CD (Auto-trigger)
 on:
   pull_request:
     branches:
-      - dev
+      - be-dev
     types:
       - closed
-    paths:
-      - "backend/**"
 
 jobs:
   deploy:
     if: github.event.pull_request.merged == true
     runs-on: [ self-hosted, dev ]
+
     defaults:
       run:
         working-directory: ./backend
+
     steps:
       - name: 최신 커밋 내역으로 checkout 한다
         uses: actions/checkout@v4
 
-      - name: EC2 환경에서 애플리케이션을 빌드 및 실행한다
+      - name: properties 파일을 갱신한다
         env:
-          APPLICATION_CLIENT_PROPERTIES: ${{ secrets.APPLICATION_DEV_CLIENT_PROPERTIES }}
+          APPLICATION_DEV_CLIENT_PROPERTIES: ${{ secrets.APPLICATION_DEV_CLIENT_PROPERTIES }}
           APPLICATION_DB_PROPERTIES: ${{ secrets.APPLICATION_DB_PROPERTIES }}
         run: |
-          # 이전 step에서 checkout한 코드로 JAR 파일을 새로 빌드한다
-          echo "=== JAR 빌드 ==="
           rm -rf src/main/resources/application-devclient.properties
-          echo "$APPLICATION_CLIENT_PROPERTIES" > src/main/resources/application-devclient.properties
+          echo "$APPLICATION_DEV_CLIENT_PROPERTIES" > src/main/resources/application-devclient.properties
           rm -rf src/main/resources/application-db.properties
           echo "$APPLICATION_DB_PROPERTIES" > src/main/resources/application-db.properties
 
-          ./gradlew --no-build-cache clean build --refresh-dependencies -Dspring.profiles.active=dev
-
-          if [ $? -ne 0 ]; then
-            echo "빌드 실패"
+      - name: 애플리케이션을 테스트한다
+        env:
+          GRADLE_FAIL_REPORT_FOLDER: "build/reports/tests/test"
+          S3_FAIL_REPORT_FOLDER: ${{ secrets.S3_BE_FAIL_REPORT_BUCKET }}
+        run: |
+          # 테스트 코드가 실패할 경우, 리포트를 S3에 업로드하고 작업을 종료한다
+          if ! ./gradlew test; then
+            echo "=== S3에 테스트 리포트 업로드 ==="
+            aws s3 cp $GRADLE_FAIL_REPORT_FOLDER $S3_FAIL_REPORT_FOLDER --recursive
             exit 1
           fi
 
+      - name: 애플리케이션을 빌드 및 실행한다
+        env:
+          LOGS_DIRECTORY: "/home/ubuntu/app-logs"
+        run: |
+          echo "=== JAR 빌드 ==="
+          ./gradlew --no-build-cache clean build -Dspring.profiles.active=dev
+
           JAR_PATH=$(ls build/libs/*SNAPSHOT.jar | head -n 1)
           if [ ! -f "$JAR_PATH" ]; then
-            echo "JAR 파일이 없습니다: $JAR_PATH"
+            echo "빌드된 JAR 파일이 없습니다: $JAR_PATH"
             exit 1
           fi
 
@@ -57,8 +67,7 @@ jobs:
 
           # 빌드한 JAR 파일을 실행시킨다
           echo "=== 앱 실행 ==="
-          mkdir -p ./logs
-          RUNNER_TRACKING_ID="" && nohup java -jar -Duser.timezone=Asia/Seoul -Dspring.profiles.active=dev "$JAR_PATH" > ./logs/nohup.log 2>&1 &
+          RUNNER_TRACKING_ID="" && nohup java -jar -Duser.timezone=Asia/Seoul -Dspring.profiles.active=dev "$JAR_PATH" > "$LOGS_DIRECTORY/nohup.log" 2>&1 &
           sleep 3
 
           NEW_PID=$(pgrep -f "$JAR_PATH" || true)
@@ -66,6 +75,6 @@ jobs:
           if [ -n "$NEW_PID" ]; then
             echo "앱 실행 성공 (PID: $NEW_PID)"
           else
-            echo "앱 실행 실패 ./logs/nohup.log"
+            echo "앱 실행 실패"
             exit 1
           fi

--- a/.github/workflows/be-cicd-dev-auto-trigger.yml
+++ b/.github/workflows/be-cicd-dev-auto-trigger.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           # 테스트 코드가 실패할 경우, 리포트를 S3에 업로드하고 작업을 종료한다
           if ! ./gradlew test; then
+            echo "🔴 테스트 실패"
             echo "=== S3에 테스트 리포트 업로드 ==="
             aws s3 cp $GRADLE_FAIL_REPORT_FOLDER $S3_FAIL_REPORT_FOLDER --recursive
             exit 1

--- a/.github/workflows/be-cicd-dev.yml
+++ b/.github/workflows/be-cicd-dev.yml
@@ -6,35 +6,47 @@ on:
 jobs:
   deploy:
     runs-on: [ self-hosted, dev ]
+
     defaults:
       run:
         working-directory: ./backend
+
     steps:
       - name: 최신 커밋 내역으로 checkout 한다
         uses: actions/checkout@v4
 
-      - name: EC2 환경에서 애플리케이션을 빌드 및 실행한다
+      - name: properties 파일을 갱신한다
         env:
-          APPLICATION_CLIENT_PROPERTIES: ${{ secrets.APPLICATION_DEV_CLIENT_PROPERTIES }}
+          APPLICATION_DEV_CLIENT_PROPERTIES: ${{ secrets.APPLICATION_DEV_CLIENT_PROPERTIES }}
           APPLICATION_DB_PROPERTIES: ${{ secrets.APPLICATION_DB_PROPERTIES }}
         run: |
-          # 이전 step에서 checkout한 코드로 JAR 파일을 새로 빌드한다
-          echo "=== JAR 빌드 ==="
           rm -rf src/main/resources/application-devclient.properties
-          echo "$APPLICATION_CLIENT_PROPERTIES" > src/main/resources/application-devclient.properties
+          echo "$APPLICATION_DEV_CLIENT_PROPERTIES" > src/main/resources/application-devclient.properties
           rm -rf src/main/resources/application-db.properties
           echo "$APPLICATION_DB_PROPERTIES" > src/main/resources/application-db.properties
-          
-          ./gradlew --no-build-cache clean build --refresh-dependencies -Dspring.profiles.active=dev
 
-          if [ $? -ne 0 ]; then
-            echo "빌드 실패"
+      - name: 애플리케이션을 테스트한다
+        env:
+          GRADLE_FAIL_REPORT_FOLDER: "build/reports/tests/test"
+          S3_FAIL_REPORT_FOLDER: ${{ secrets.S3_BE_FAIL_REPORT_BUCKET }}
+        run: |
+          # 테스트 코드가 실패할 경우, 리포트를 S3에 업로드하고 작업을 종료한다
+          if ! ./gradlew test; then
+            echo "=== S3에 테스트 리포트 업로드 ==="
+            aws s3 cp $GRADLE_FAIL_REPORT_FOLDER $S3_FAIL_REPORT_FOLDER --recursive
             exit 1
           fi
 
+      - name: 애플리케이션을 빌드 및 실행한다
+        env:
+          LOGS_DIRECTORY: "/home/ubuntu/app-logs"
+        run: |
+          echo "=== JAR 빌드 ==="
+          ./gradlew --no-build-cache clean build -Dspring.profiles.active=dev
+
           JAR_PATH=$(ls build/libs/*SNAPSHOT.jar | head -n 1)
           if [ ! -f "$JAR_PATH" ]; then
-            echo "JAR 파일이 없습니다: $JAR_PATH"
+            echo "빌드된 JAR 파일이 없습니다: $JAR_PATH"
             exit 1
           fi
 
@@ -50,8 +62,7 @@ jobs:
 
           # 빌드한 JAR 파일을 실행시킨다
           echo "=== 앱 실행 ==="
-          mkdir -p ./logs
-          RUNNER_TRACKING_ID="" && nohup java -jar -Duser.timezone=Asia/Seoul -Dspring.profiles.active=dev "$JAR_PATH" > ./logs/nohup.log 2>&1 &
+          RUNNER_TRACKING_ID="" && nohup java -jar -Duser.timezone=Asia/Seoul -Dspring.profiles.active=dev "$JAR_PATH" > "$LOGS_DIRECTORY/nohup.log" 2>&1 &
           sleep 3
 
           NEW_PID=$(pgrep -f "$JAR_PATH" || true)
@@ -59,6 +70,6 @@ jobs:
           if [ -n "$NEW_PID" ]; then
             echo "앱 실행 성공 (PID: $NEW_PID)"
           else
-            echo "앱 실행 실패 ./logs/nohup.log"
+            echo "앱 실행 실패"
             exit 1
           fi

--- a/.github/workflows/be-cicd-dev.yml
+++ b/.github/workflows/be-cicd-dev.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           # 테스트 코드가 실패할 경우, 리포트를 S3에 업로드하고 작업을 종료한다
           if ! ./gradlew test; then
+            echo "🔴 테스트 실패"
             echo "=== S3에 테스트 리포트 업로드 ==="
             aws s3 cp $GRADLE_FAIL_REPORT_FOLDER $S3_FAIL_REPORT_FOLDER --recursive
             exit 1

--- a/.github/workflows/be-cicd-prod-auto-trigger.yml
+++ b/.github/workflows/be-cicd-prod-auto-trigger.yml
@@ -3,11 +3,9 @@ name: Backend 운영 서버 CI/CD (Auto-trigger)
 on:
   pull_request:
     branches:
-      - main
+      - be-prod
     types:
       - closed
-    paths:
-      - "backend/**"
 
 jobs:
   deploy_prod:
@@ -24,23 +22,32 @@ jobs:
       - name: 최신 커밋 내역으로 checkout 한다
         uses: actions/checkout@v4
 
-      - name: 애플리케이션을 빌드하고 빌드 파일을 백업한다
+      - name: properties 파일을 갱신한다
         env:
           APPLICATION_CLIENT_PROPERTIES: ${{ secrets.APPLICATION_CLIENT_PROPERTIES }}
           APPLICATION_DB_PROPERTIES: ${{ secrets.APPLICATION_DB_PROPERTIES }}
         run: |
-          echo "=== JAR 빌드 ==="
           rm -rf src/main/resources/application-client.properties
           echo "$APPLICATION_CLIENT_PROPERTIES" > src/main/resources/application-client.properties
           rm -rf src/main/resources/application-db.properties
           echo "$APPLICATION_DB_PROPERTIES" > src/main/resources/application-db.properties
-          
-          ./gradlew --no-build-cache clean build --refresh-dependencies -Dspring.profiles.active=prod
 
-          if [ $? -ne 0 ]; then
-            echo "빌드 실패"
+      - name: 애플리케이션을 테스트한다
+        env:
+          GRADLE_FAIL_REPORT_FOLDER: "build/reports/tests/test"
+          S3_FAIL_REPORT_FOLDER: ${{ secrets.S3_BE_FAIL_REPORT_BUCKET }}
+        run: |
+          # 테스트 코드가 실패할 경우, 리포트를 S3에 업로드하고 작업을 종료한다
+          if ! ./gradlew test; then
+            echo "=== S3에 테스트 리포트 업로드 ==="
+            aws s3 cp $GRADLE_FAIL_REPORT_FOLDER $S3_FAIL_REPORT_FOLDER --recursive
             exit 1
           fi
+
+      - name: 애플리케이션을 빌드하고 빌드 파일을 백업한다
+        run: |
+          echo "=== JAR 빌드 ==="
+          ./gradlew --no-build-cache clean build -Dspring.profiles.active=prod
 
           if [ ! -f $(ls ./build/libs/*SNAPSHOT.jar | head -n 1) ]; then
             echo "빌드된 JAR 파일이 없습니다"
@@ -57,7 +64,9 @@ jobs:
           FILE_PATH=$(ls *SNAPSHOT.jar | head -n 1)
           aws s3 cp "${FILE_PATH}" "${S3_BUCKET}/${FILE_PATH}" --only-show-errors
 
-      - name: 빌드 파일을 백업한 후 애플리케이션을 실행한다
+      - name: 애플리케이션을 실행한다
+        env:
+          LOGS_DIRECTORY: "/var/snap/amazon-ssm-agent/11798/app-logs"
         run: |
           JAR_PATH=$(ls ./build/libs/*SNAPSHOT.jar | head -n 1)
 
@@ -73,7 +82,7 @@ jobs:
 
           # 빌드한 JAR 파일을 실행시킨다
           echo "=== 앱 실행 ==="
-          RUNNER_TRACKING_ID="" && nohup java -Duser.timezone=Asia/Seoul -Dspring.profiles.active=prod -jar "$JAR_PATH" > /dev/null 2>&1 &
+          RUNNER_TRACKING_ID="" && nohup java -jar -Duser.timezone=Asia/Seoul -Dspring.profiles.active=prod "$JAR_PATH" > "$LOGS_DIRECTORY/nohup.log" 2>&1 &
           sleep 3
 
           NEW_PID=$(pgrep -f "$JAR_PATH" || true)

--- a/.github/workflows/be-cicd-prod-auto-trigger.yml
+++ b/.github/workflows/be-cicd-prod-auto-trigger.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           # 테스트 코드가 실패할 경우, 리포트를 S3에 업로드하고 작업을 종료한다
           if ! ./gradlew test; then
+            echo "🔴 테스트 실패"
             echo "=== S3에 테스트 리포트 업로드 ==="
             aws s3 cp $GRADLE_FAIL_REPORT_FOLDER $S3_FAIL_REPORT_FOLDER --recursive
             exit 1

--- a/.github/workflows/be-cicd-prod.yml
+++ b/.github/workflows/be-cicd-prod.yml
@@ -17,23 +17,32 @@ jobs:
       - name: 최신 커밋 내역으로 checkout 한다
         uses: actions/checkout@v4
 
-      - name: 애플리케이션을 빌드하고 빌드 파일을 백업한다
+      - name: properties 파일을 갱신한다
         env:
           APPLICATION_CLIENT_PROPERTIES: ${{ secrets.APPLICATION_CLIENT_PROPERTIES }}
           APPLICATION_DB_PROPERTIES: ${{ secrets.APPLICATION_DB_PROPERTIES }}
         run: |
-          echo "=== JAR 빌드 ==="
           rm -rf src/main/resources/application-client.properties
           echo "$APPLICATION_CLIENT_PROPERTIES" > src/main/resources/application-client.properties
           rm -rf src/main/resources/application-db.properties
           echo "$APPLICATION_DB_PROPERTIES" > src/main/resources/application-db.properties
-          
-          ./gradlew --no-build-cache clean build --refresh-dependencies -Dspring.profiles.active=prod
 
-          if [ $? -ne 0 ]; then
-            echo "빌드 실패"
+      - name: 애플리케이션을 테스트한다
+        env:
+          GRADLE_FAIL_REPORT_FOLDER: "build/reports/tests/test"
+          S3_FAIL_REPORT_FOLDER: ${{ secrets.S3_BE_FAIL_REPORT_BUCKET }}
+        run: |
+          # 테스트 코드가 실패할 경우, 리포트를 S3에 업로드하고 작업을 종료한다
+          if ! ./gradlew test; then
+            echo "=== S3에 테스트 리포트 업로드 ==="
+            aws s3 cp $GRADLE_FAIL_REPORT_FOLDER $S3_FAIL_REPORT_FOLDER --recursive
             exit 1
           fi
+
+      - name: 애플리케이션을 빌드하고 빌드 파일을 백업한다
+        run: |
+          echo "=== JAR 빌드 ==="
+          ./gradlew --no-build-cache clean build -Dspring.profiles.active=prod
 
           if [ ! -f $(ls ./build/libs/*SNAPSHOT.jar | head -n 1) ]; then
             echo "빌드된 JAR 파일이 없습니다"
@@ -50,7 +59,9 @@ jobs:
           FILE_PATH=$(ls *SNAPSHOT.jar | head -n 1)
           aws s3 cp "${FILE_PATH}" "${S3_BUCKET}/${FILE_PATH}" --only-show-errors
 
-      - name: 빌드 파일을 백업한 후 애플리케이션을 실행한다
+      - name: 애플리케이션을 실행한다
+        env:
+          LOGS_DIRECTORY: "/var/snap/amazon-ssm-agent/11798/app-logs"
         run: |
           JAR_PATH=$(ls ./build/libs/*SNAPSHOT.jar | head -n 1)
 
@@ -66,7 +77,7 @@ jobs:
 
           # 빌드한 JAR 파일을 실행시킨다
           echo "=== 앱 실행 ==="
-          RUNNER_TRACKING_ID="" && nohup java -Duser.timezone=Asia/Seoul -Dspring.profiles.active=prod -jar "$JAR_PATH" > /dev/null 2>&1 &
+          RUNNER_TRACKING_ID="" && nohup java -jar -Duser.timezone=Asia/Seoul -Dspring.profiles.active=prod "$JAR_PATH" > "$LOGS_DIRECTORY/nohup.log" 2>&1 &
           sleep 3
 
           NEW_PID=$(pgrep -f "$JAR_PATH" || true)

--- a/.github/workflows/be-cicd-prod.yml
+++ b/.github/workflows/be-cicd-prod.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           # 테스트 코드가 실패할 경우, 리포트를 S3에 업로드하고 작업을 종료한다
           if ! ./gradlew test; then
+            echo "🔴 테스트 실패"
             echo "=== S3에 테스트 리포트 업로드 ==="
             aws s3 cp $GRADLE_FAIL_REPORT_FOLDER $S3_FAIL_REPORT_FOLDER --recursive
             exit 1


### PR DESCRIPTION
# #️⃣ Issue Number
#406 

## 🕹️ 작업 내용

한 줄 요약 : CI/CD 단계를 분리하고 테스트 코드가 실패하면 그 결과물을 S3에 업로드해서 직접 확인해볼 수 있도록 수정했습니다.

- [x] CI 파트와 CD 파트 분리
- [x] 테스트 리포트를 S3에 업로드하는 스크립트 추가
- [x] BE, FE 브랜치가 분리됨에 따라 trigger하는 브랜치 수정

## 📋 리뷰 포인트

- 로직상 오류가 없을지?
- 기타 오타가 없을지?