### PR TITLE
[BE] refactor: 카테고리 명사화 중 복수형 카테고리에 대한 문제 해결 

### DIFF
--- a/backend/src/main/java/com/f12/moitz/application/RecommendationService.java
+++ b/backend/src/main/java/com/f12/moitz/application/RecommendationService.java
@@ -68,7 +68,6 @@ public class RecommendationService {
         stopWatch.start("지역 추천");
         final List<RecommendCondition> recommendConditions = RecommendCondition.fromTitle(request.requirements());
         final List<String> requirements = RecommendCondition.getRequirements(recommendConditions);
-        log.info(requirements.toString());
         final List<SubwayStation> startingPlaces = getByNames(request.startingPlaceNames());
         final List<SubwayStation> candidatePlaces = subwayStationService.generateCandidatePlace(startingPlaces);
 

--- a/backend/src/main/java/com/f12/moitz/application/dto/RecommendationRequest.java
+++ b/backend/src/main/java/com/f12/moitz/application/dto/RecommendationRequest.java
@@ -9,7 +9,7 @@ import java.util.List;
 public record RecommendationRequest(
         @Schema(description = "출발지 이름 목록", example = "[\"강변역\", \"동대문역\", \"서울대입구역\"]", requiredMode = Schema.RequiredMode.REQUIRED)
         List<String> startingPlaceNames,
-        @Schema(description = "카테고리에 따른 조건", example = "CHAT")
+        @Schema(description = "카테고리에 따른 조건", example = "[\"CAFE\", \"RESTAURANT\",\"PC_ROOM_KARAOKE\"]")
         List<String> requirements
 ) {
 

--- a/backend/src/main/java/com/f12/moitz/application/dto/RecommendationResponse.java
+++ b/backend/src/main/java/com/f12/moitz/application/dto/RecommendationResponse.java
@@ -25,7 +25,55 @@ public record RecommendationResponse(
         String description,
         @Schema(description = "지역 추천 이유", example = "유명한 곱창집이 있고, 전체적으로 환승을 하지 않는 최적의 지역입니다!", requiredMode = Schema.RequiredMode.REQUIRED)
         String reason,
-        @Schema(description = "추천 장소 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(
+                description = "카테고리별 추천 장소 목록",
+                example = """
+                {
+                  "PC_ROOM_KARAOKE": [
+                    {
+                      "index": 1,
+                      "x": 127.007079969366,
+                      "y": 37.5657600421876,
+                      "name": "GGX",
+                      "category": "게임방,PC방",
+                      "walkingTime": 3,
+                      "url": "http://place.map.kakao.com/1381860160"
+                    },
+                    {
+                      "index": 2,
+                      "x": 127.006320492392,
+                      "y": 37.5660078592087,
+                      "name": "캐슬노래연습장",
+                      "category": "노래방",
+                      "walkingTime": 4,
+                      "url": "http://place.map.kakao.com/324019013"
+                    }
+                  ],
+                  "RESTAURANT": [
+                    {
+                      "index": 1,
+                      "x": 127.00669603395768,
+                      "y": 37.56324808702588,
+                      "name": "평양면옥 본점",
+                      "category": "냉면",
+                      "walkingTime": 5,
+                      "url": "http://place.map.kakao.com/13093208"
+                    }
+                  ],
+                  "CAFE": [
+                    {
+                      "index": 1,
+                      "x": 127.007230456427,
+                      "y": 37.5651987124977,
+                      "name": "스타벅스 동대문공원점",
+                      "category": "카페",
+                      "walkingTime": 2,
+                      "url": "http://place.map.kakao.com/321907882"
+                    }
+                  ]
+                }
+                """
+        )
         Map<RecommendCondition,List<PlaceRecommendResponse>> places,
         @Schema(description = "각 출발지로부터 이동 경로", requiredMode = Schema.RequiredMode.REQUIRED)
         List<RouteResponse> routes

--- a/backend/src/main/java/com/f12/moitz/application/utils/RecommendationMapper.java
+++ b/backend/src/main/java/com/f12/moitz/application/utils/RecommendationMapper.java
@@ -45,9 +45,7 @@ public class RecommendationMapper {
     }
 
     private List<String> getCondition(final Result result) {
-        final List<RecommendCondition> recommendConditions =
-                result.getRecommendConditions() == null ? List.of(RecommendCondition.NOT_SELECTED)
-                : result.getRecommendConditions();
+        final List<RecommendCondition> recommendConditions = result.getRecommendConditions();
 
         return recommendConditions.stream()
                 .map(RecommendCondition::getTitle)

--- a/backend/src/main/java/com/f12/moitz/common/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/f12/moitz/common/config/SwaggerConfig.java
@@ -28,7 +28,7 @@ public class SwaggerConfig {
         final Info info = new Info()
                 .title(title)
                 .description(description)
-                .version("1.0.0");
+                .version("2.0.0");
 
         return new OpenAPI()
                 .addServersItem(new Server().url("/"))

--- a/backend/src/main/java/com/f12/moitz/domain/RecommendCondition.java
+++ b/backend/src/main/java/com/f12/moitz/domain/RecommendCondition.java
@@ -5,7 +5,9 @@ import com.f12.moitz.common.error.exception.GeneralErrorCode;
 import java.util.Arrays;
 import java.util.List;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Getter
 public enum RecommendCondition {
 
@@ -14,11 +16,9 @@ public enum RecommendCondition {
     BAR("BAR","술집"),
     STUDY_CAFE("STUDY_CAFE", "스터디카페"),
     SPACE_RENTAL("SPACE_RENTAL", "공간대여"),
-    PC_ROOM("PC_ROOM", "PC방"),
-    KARAOKE("KARAOKE", "노래방"),
-    ACTIVITY("ACTIVITY", List.of("클라이밍, 볼링, 사격, 당구")),
-    ENTERTAINMENT("ENTERTAINMENT", List.of("방탈출, 만화방, 보드게임카페, 영화관")),
-    NOT_SELECTED("NOT_SELECTED", "맛집");
+    PC_ROOM_KARAOKE("PC_ROOM_KARAOKE", List.of("PC방", "노래방")),
+    ACTIVITY("ACTIVITY", List.of("클라이밍", "볼링", "사격", "당구")),
+    ENTERTAINMENT("ENTERTAINMENT", List.of("방탈출", "만화방", "보드게임카페", "영화관"));
 
     private final String title;
     private final List<String> keywords;
@@ -59,6 +59,5 @@ public enum RecommendCondition {
                 .orElseThrow(() -> new BadRequestException(GeneralErrorCode.INPUT_INVALID_DESCRIPTION, keyword));
     }
 
-
-
 }
+

--- a/backend/src/main/java/com/f12/moitz/infrastructure/PromptGenerator.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/PromptGenerator.java
@@ -1,6 +1,7 @@
 package com.f12.moitz.infrastructure;
 
 import com.f12.moitz.domain.Place;
+import com.f12.moitz.domain.RecommendCondition;
 import com.f12.moitz.infrastructure.client.kakao.dto.KakaoApiResponse;
 import com.f12.moitz.infrastructure.client.kakao.dto.KakaoApiResponses;
 import java.util.List;
@@ -225,7 +226,7 @@ public class PromptGenerator {
                 place.getPoint().getX(), place.getPoint().getY()));
         sb.append("Search Results:\n");
 
-        final Map<String, List<KakaoApiResponse>> kakaoApiResponses = kakaoResponses.kakaoApiResponses();
+        final Map<RecommendCondition, List<KakaoApiResponse>> kakaoApiResponses = kakaoResponses.kakaoApiResponses();
 
         kakaoApiResponses.forEach((category, responses) -> {
             sb.append(String.format("Category: %s\n", category));

--- a/backend/src/main/java/com/f12/moitz/infrastructure/adapter/LocationRecommenderAdapter.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/adapter/LocationRecommenderAdapter.java
@@ -71,17 +71,18 @@ public class LocationRecommenderAdapter implements LocationRecommender {
 
     @Recover
     public RecommendedLocationsResponse recoverRecommendedLocations(
-            final List<String> startPlaceNames,
-            final String condition
+            final List<String> startingPlaces,
+            final List<String> candidatePlaces,
+            final List<String> requirements
     ) {
         final RecommendedLocationsResponse generatedResponse = perplexityClient.generateResponse(
-                startPlaceNames,
-                condition
+                startingPlaces,
+                String.join(",", requirements)
         );
         final RecommendedLocationsResponse deduplicatedLocations = deduplicateLocation(generatedResponse);
         return excludeStartPlaces(
                 deduplicatedLocations,
-                startPlaceNames
+                startingPlaces
         );
     }
 

--- a/backend/src/main/java/com/f12/moitz/infrastructure/adapter/PlaceRecommenderAdapter.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/adapter/PlaceRecommenderAdapter.java
@@ -40,7 +40,7 @@ public class PlaceRecommenderAdapter implements PlaceRecommender {
                                         .kakaoApiResponses()
                                         .entrySet().stream()
                                         .collect(Collectors.toMap(
-                                                reqEntry -> RecommendCondition.fromTitle(reqEntry.getKey()),
+                                                Entry::getKey,
                                                 reqEntry -> reqEntry.getValue().stream()
                                                         .flatMap(resp -> resp.documents().stream())
                                                         .map(document -> new RecommendedPlace(
@@ -62,9 +62,9 @@ public class PlaceRecommenderAdapter implements PlaceRecommender {
                 .collect(Collectors.toMap(
                         place -> place,
                         place -> {
-                            Map<String,List<KakaoApiResponse>> responsesByCategory =
+                            Map<RecommendCondition,List<KakaoApiResponse>> responsesByCategory =
                                     requirements.stream().collect(Collectors.toMap(
-                                            requirement -> RecommendCondition.fromKeyword(requirement).getTitle(),
+                                            RecommendCondition::fromKeyword,
                                             requirement -> {
                                                 KakaoApiResponse response = kakaoMapClient.searchPlacesBy(
                                                         new SearchPlacesLimitQuantityRequest(

--- a/backend/src/main/java/com/f12/moitz/infrastructure/adapter/PlaceRecommenderAdapter.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/adapter/PlaceRecommenderAdapter.java
@@ -10,6 +10,7 @@ import com.f12.moitz.infrastructure.client.kakao.KakaoMapClient;
 import com.f12.moitz.infrastructure.client.kakao.dto.KakaoApiResponse;
 import com.f12.moitz.infrastructure.client.kakao.dto.KakaoApiResponses;
 import com.f12.moitz.infrastructure.client.kakao.dto.SearchPlacesLimitQuantityRequest;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -74,7 +75,10 @@ public class PlaceRecommenderAdapter implements PlaceRecommender {
                                                                 3
                                                         )
                                                 );
-                                                return List.of(response);
+                                                return new ArrayList<>(List.of(response));                                            },
+                                            (existing, incoming) -> {
+                                                existing.addAll(incoming);
+                                                return existing;
                                             }
                                     ));
                             return new KakaoApiResponses(responsesByCategory);

--- a/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/dto/KakaoApiResponses.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/dto/KakaoApiResponses.java
@@ -1,10 +1,11 @@
 package com.f12.moitz.infrastructure.client.kakao.dto;
 
+import com.f12.moitz.domain.RecommendCondition;
 import java.util.List;
 import java.util.Map;
 
 public record KakaoApiResponses(
-        Map<String, List<KakaoApiResponse>> kakaoApiResponses
+        Map<RecommendCondition, List<KakaoApiResponse>> kakaoApiResponses
 ) {
 
 }

--- a/backend/src/main/java/com/f12/moitz/ui/MockingRecommendationController.java
+++ b/backend/src/main/java/com/f12/moitz/ui/MockingRecommendationController.java
@@ -62,7 +62,7 @@ public class MockingRecommendationController implements SwaggerMockingRecommenda
                                                         "http://place.map.kakao.com/666587821"
                                                 )
                                         ),
-                                        RecommendCondition.PC_ROOM, List.of(
+                                        RecommendCondition.PC_ROOM_KARAOKE, List.of(
                                                 new PlaceRecommendResponse(
                                                         1, 127.094741101863, 37.5351180385975,
                                                         "포포PC방 건대점", "PC방", 1,
@@ -109,7 +109,7 @@ public class MockingRecommendationController implements SwaggerMockingRecommenda
                                                         "http://place.map.kakao.com/23447734"
                                                 )
                                         ),
-                                        RecommendCondition.PC_ROOM,List.of(
+                                        RecommendCondition.PC_ROOM_KARAOKE,List.of(
                                                 new PlaceRecommendResponse(
                                                         3, 127.094741101863, 37.5351180385975,
                                                         "레벨업PC방 사당역점", "PC방", 2,
@@ -150,7 +150,7 @@ public class MockingRecommendationController implements SwaggerMockingRecommenda
                                                         "http://place.map.kakao.com/10809505"
                                                 )
                                         ),
-                                        RecommendCondition.PC_ROOM,List.of(
+                                        RecommendCondition.PC_ROOM_KARAOKE,List.of(
                                                 new PlaceRecommendResponse(3, 127.094741101863, 37.5351180385975,
                                                         "이스포츠PC방 왕십리점", "PC방", 2,
                                                         "http://place.map.kakao.com/12326220"
@@ -196,7 +196,7 @@ public class MockingRecommendationController implements SwaggerMockingRecommenda
                                                         "http://place.map.kakao.com/1784996243"
                                                 )
                                         ),
-                                        RecommendCondition.PC_ROOM,List.of(
+                                        RecommendCondition.PC_ROOM_KARAOKE,List.of(
                                                 new PlaceRecommendResponse(3, 127.094741101863, 37.5351180385975,
                                                         "옵티멈존 PC카페 종각역점", "PC방", 1,
                                                         "http://place.map.kakao.com/1342335656"
@@ -250,7 +250,7 @@ public class MockingRecommendationController implements SwaggerMockingRecommenda
                                                         "http://place.map.kakao.com/23634722"
                                                 )
                                         ),
-                                        RecommendCondition.PC_ROOM,List.of(
+                                        RecommendCondition.PC_ROOM_KARAOKE,List.of(
                                                 new PlaceRecommendResponse(
                                                         3, 127.094741101863, 37.5351180385975,
                                                         "에스엔에스 피씨SNS PC", "PC방", 1,


### PR DESCRIPTION


# #️⃣ Issue Number
#438 

## 🕹️ 작업 내용 

PlaceRecommenderAdapter 클래스의 searchPlacesWithRequirement() 메서드에서 Map<String, List>를 반환하고있습니다.
Map 생성 과정 중 ACTIVITY의 경우 ACTIVITY 라는 중복되는 키에 리스트들을 추가하고 있어 예외가 발생하던 문제를 merge 메서드를 통해 해결했습니다.


한 줄 요약 :

- PlaceRecommenderAdapter 의 searchPlacesWithRequirement() 메서드에서 하나의 키에 여러 리스트들을 merge 하게하는 로직 추가

- RecommendCondition의의 PC방과 노래방이 분리되어있던 것을 하나로 병합


## 📋 리뷰 포인트

- 오타 확인
- RecommendCondtion의 pc방과 노래방에 대한 변수명 체크

## 🔮 기타 사항

-
-
