### PR TITLE
[FE] fix: ESLint 규칙과 Prettier 규칙 간의 충돌을 eslint-config-prettier 를 사용하여 해결하도록 수정

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -2,6 +2,7 @@
 import js from '@eslint/js';
 import tseslint from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
+import prettier from 'eslint-config-prettier';
 import pluginImport from 'eslint-plugin-import';
 import pluginReact from 'eslint-plugin-react';
 import storybook from 'eslint-plugin-storybook';
@@ -61,6 +62,7 @@ export default [
 
       // emotion css prop를 쓰기 위한 규칙
       'react/no-unknown-property': ['error', { ignore: ['css'] }],
+      indent: ['error', 2],
       'import/order': [
         'error',
         {
@@ -157,4 +159,5 @@ export default [
     ignores: ['**/node_modules/**', '**/dist/**', '**/build/**'],
   },
   ...storybook.configs['flat/recommended'],
+  prettier,
 ];

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,6 +37,7 @@
         "css-loader": "^7.1.2",
         "dotenv": "^17.2.1",
         "eslint": "^9.30.1",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-storybook": "^9.0.17",
@@ -8514,6 +8515,22 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "css-loader": "^7.1.2",
     "dotenv": "^17.2.1",
     "eslint": "^9.30.1",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-storybook": "^9.0.17",


### PR DESCRIPTION
# #️⃣ Issue Number
#454 

## 🕹️ 작업 내용

한 줄 요약 : ESLint와 Prettier 간의 스타일 규칙 충돌 해결을 위해 eslint-config-prettier 도입

- [x] eslint-config-prettier 패키지 설치
- [x] ESLint 설정 파일에 prettier 설정 추가
- [x] 기존 indent 규칙 제거

## 📋 리뷰 포인트

- [ ] eslint-config-prettier가 올바르게 설정되었는지 확인해주세요
- [ ] 기존 indent 관련 충돌 문제가 해결되었는지 확인해주세요


## 🔮 기타 사항

- 이전 PR (#403)에서는 ESLint의 indent 규칙을 수동으로 끄는 방식으로 문제를 해결했습니다.
    <details>
    <summary>변경 이유</summary>
    
    - 현재는 정상적으로 동작하지만, 다음과 같은 이슈가 있습니다:
      1. 추가 ESLint 플러그인 도입 시 새로운 스타일 규칙들(quotes, semi 등)과의 충돌 가능성
      2. 향후 발생하는 충돌마다 수동으로 규칙을 끄는 작업 필요
      3. 팀 협업 중 설정 변경 시 규칙 충돌 이력을 모르면 의도치 않게 규칙이 다시 활성화될 수 있어 규칙 관리의 어려움
    
    - 이를 해결하기 위해 `eslint-config-prettier`를 사용하도록 수정했습니다:
      1. Prettier와 충돌 가능한 모든 ESLint 스타일 규칙을 자동으로 비활성화
      2. ESLint는 코드 품질 검사에, Prettier는 스타일링에 집중
      3. 향후 발생할 수 있는 스타일 규칙 충돌을 사전에 방지
    
    - 참고 문서:
      - [Prettier 공식 문서](https://prettier.io/docs/integrating-with-linters)
      - [이전 PR 논의 내용](https://github.com/woowacourse-teams/2025-moitz/pull/403#issuecomment-3339530746)
    
    - 관련 내용은 [문서](https://eunsoa.notion.site/Moitz-fix-ESLint-indent-Prettier-eslint-config-prettier-292b5a1edfe480508c9fc9797d15e48d?source=copy_link)에서 자세한 내용을 확인하실 수 있습니다.
    </details>

- thx to 중곤쓰