### PR TITLE
[FE] feat: indexPage 변경된 디자인으로 퍼블리싱

### DIFF
--- a/frontend/src/entities/location/api/fetchRecommendationResult.ts
+++ b/frontend/src/entities/location/api/fetchRecommendationResult.ts
@@ -8,7 +8,7 @@ export const fetchRecommendationResult = async (
 ): Promise<Location> => {
   const data = await apiClient.get<LocationResponse>(`/recommendations/${id}`);
   const transformedData: Location = {
-    requirement: data.requirement,
+    requirements: data.requirements,
     startingPlaces: data.startingPlaces,
     recommendedLocations: data.locations,
   };

--- a/frontend/src/entities/location/api/types/RecommendationIdAPI.ts
+++ b/frontend/src/entities/location/api/types/RecommendationIdAPI.ts
@@ -2,7 +2,7 @@ import { LocationRequirement } from '@entities/location/types/LocationRequiremen
 
 export type RecommendationRequestBody = {
   startingPlaceNames: string[];
-  requirement: LocationRequirement;
+  requirements: LocationRequirement[];
 };
 
 export type RecommendationResponse = {

--- a/frontend/src/entities/location/api/types/RecommendationResultAPI.ts
+++ b/frontend/src/entities/location/api/types/RecommendationResultAPI.ts
@@ -50,7 +50,7 @@ export type RecommendedLocationResponse = {
 };
 
 export type LocationResponse = {
-  requirement: LocationRequirement;
+  requirements: LocationRequirement[];
   startingPlaces: StartingPlaceResponse[];
   locations: RecommendedLocationResponse[];
 };

--- a/frontend/src/entities/location/hooks/useLocations.test.ts
+++ b/frontend/src/entities/location/hooks/useLocations.test.ts
@@ -110,7 +110,7 @@ describe('useLocations', () => {
         expect(result.current.isLoading).toBe(false);
         expect(result.current.isError).toBe(true);
         expect(result.current.data).toEqual({
-          requirement: 'NOT_SELECTED',
+          requirements: [],
           startingPlaces: [],
           recommendedLocations: [],
         });

--- a/frontend/src/entities/location/hooks/useLocations.ts
+++ b/frontend/src/entities/location/hooks/useLocations.ts
@@ -21,7 +21,7 @@ export type useLocationsReturn = {
 };
 
 const initialData: Location = {
-  requirement: 'NOT_SELECTED',
+  requirements: [],
   startingPlaces: [],
   recommendedLocations: [],
 };

--- a/frontend/src/entities/location/model/meetingStorage.ts
+++ b/frontend/src/entities/location/model/meetingStorage.ts
@@ -5,7 +5,7 @@ const MEETING_CONDITION_ID = 'meeting:conditionId';
 
 export function setMeetingStorage(params: {
   departureList: string[];
-  conditionID: LocationRequirement;
+  conditionIDs: LocationRequirement[];
 }) {
   localStorage.setItem(
     MEETING_DEPARTURE_LIST,
@@ -13,20 +13,20 @@ export function setMeetingStorage(params: {
   );
   localStorage.setItem(
     MEETING_CONDITION_ID,
-    JSON.stringify(params.conditionID),
+    JSON.stringify(params.conditionIDs),
   );
 }
 
 export function getMeetingStorage(): {
   departureList: string[];
-  conditionID: LocationRequirement;
-  } {
+  conditionIDs: LocationRequirement[];
+} {
   const departureList = JSON.parse(
     localStorage.getItem(MEETING_DEPARTURE_LIST) ?? '[]',
   );
-  const conditionID = JSON.parse(
-    localStorage.getItem(MEETING_CONDITION_ID) ?? 'null',
+  const conditionIDs = JSON.parse(
+    localStorage.getItem(MEETING_CONDITION_ID) ?? '[]',
   );
 
-  return { departureList, conditionID };
+  return { departureList, conditionIDs };
 }

--- a/frontend/src/entities/location/types/Location.ts
+++ b/frontend/src/entities/location/types/Location.ts
@@ -50,7 +50,7 @@ export type RecommendedLocation = {
 };
 
 export type Location = {
-  requirement: LocationRequirement;
+  requirements: LocationRequirement[];
   startingPlaces: StartingPlace[];
   recommendedLocations: RecommendedLocation[];
 };

--- a/frontend/src/entities/location/types/LocationRequirement.ts
+++ b/frontend/src/entities/location/types/LocationRequirement.ts
@@ -1,6 +1,9 @@
 export type LocationRequirement =
-  | 'CHAT'
-  | 'MEETING'
-  | 'FOCUS'
-  | 'DATE'
-  | 'NOT_SELECTED';
+  | 'CAFE'
+  | 'RESTAURANT'
+  | 'BAR'
+  | 'STUDY_CAFE'
+  | 'SPACE_RENTAL'
+  | 'PC_ROOM_KARAOKE'
+  | 'ACTIVITY'
+  | 'ENTERTAINMENT';

--- a/frontend/src/features/meeting/components/conditionCard/ConditionCard.tsx
+++ b/frontend/src/features/meeting/components/conditionCard/ConditionCard.tsx
@@ -25,7 +25,7 @@ function ConditionCard({
       type="button"
       onClick={onClick}
     >
-      <div css={[typography.b1, conditionCard.text()]}>{iconText}</div>
+      <div css={[typography.b1, conditionCard.icon()]}>{iconText}</div>
       <div css={[typography.b1, conditionCard.text()]}>{contentText}</div>
     </button>
   );

--- a/frontend/src/features/meeting/components/conditionCard/ConditionCard.tsx
+++ b/frontend/src/features/meeting/components/conditionCard/ConditionCard.tsx
@@ -5,6 +5,7 @@ import * as conditionCard from './conditionCard.styled';
 interface ConditionCardProps {
   iconText: string;
   contentText: string;
+  descriptionText: string;
   onClick: () => void;
   isSelected?: boolean;
 }
@@ -12,6 +13,7 @@ interface ConditionCardProps {
 function ConditionCard({
   iconText,
   contentText,
+  descriptionText,
   onClick,
   isSelected = false,
 }: ConditionCardProps) {
@@ -27,6 +29,9 @@ function ConditionCard({
     >
       <div css={[typography.b1, conditionCard.icon()]}>{iconText}</div>
       <div css={[typography.b1, conditionCard.text()]}>{contentText}</div>
+      <div css={[typography.c2, conditionCard.description()]}>
+        {descriptionText}
+      </div>
     </button>
   );
 }

--- a/frontend/src/features/meeting/components/conditionCard/conditionCard.stories.ts
+++ b/frontend/src/features/meeting/components/conditionCard/conditionCard.stories.ts
@@ -17,6 +17,10 @@ const meta = {
       control: { type: 'text' },
       description: '컨텐츠에 표시될 텍스트',
     },
+    descriptionText: {
+      control: { type: 'text' },
+      description: '설명 텍스트',
+    },
     onClick: {
       description: '클릭 시 실행될 함수',
     },
@@ -32,8 +36,9 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    iconText: '💬',
-    contentText: '떠들고 놀기 좋은',
+    iconText: '☕️',
+    contentText: '카페',
+    descriptionText: '',
     onClick: () => {},
     isSelected: false,
   },
@@ -41,8 +46,9 @@ export const Default: Story = {
 
 export const Selected: Story = {
   args: {
-    iconText: '💬',
-    contentText: '떠들고 놀기 좋은',
+    iconText: '☕️',
+    contentText: '카페',
+    descriptionText: '',
     onClick: () => {},
     isSelected: true,
   },

--- a/frontend/src/features/meeting/components/conditionCard/conditionCard.styled.ts
+++ b/frontend/src/features/meeting/components/conditionCard/conditionCard.styled.ts
@@ -14,6 +14,10 @@ export const base = () => css`
   }
 `;
 
+export const icon = () => css`
+  font-family: 'Tossface';
+`;
+
 export const text = () => css`
   color: ${colorToken.gray[2]};
 `;

--- a/frontend/src/features/meeting/components/conditionCard/conditionCard.styled.ts
+++ b/frontend/src/features/meeting/components/conditionCard/conditionCard.styled.ts
@@ -22,6 +22,10 @@ export const text = () => css`
   color: ${colorToken.gray[2]};
 `;
 
+export const description = () => css`
+  color: ${colorToken.gray[5]};
+`;
+
 export const selected = () => css`
   background-color: ${colorToken.main[4]};
   box-shadow: 0 0 0 2px ${colorToken.main[1]};

--- a/frontend/src/features/meeting/components/conditionSelector/ConditionSelector.tsx
+++ b/frontend/src/features/meeting/components/conditionSelector/ConditionSelector.tsx
@@ -21,6 +21,7 @@ function ConditionSelector({
 
   return (
     <InputFormSection
+      iconText={INPUT_FORM_TEXT.CONDITION.ICON}
       titleText={INPUT_FORM_TEXT.CONDITION.TITLE}
       descriptionText={INPUT_FORM_TEXT.CONDITION.DESCRIPTION}
     >

--- a/frontend/src/features/meeting/components/conditionSelector/ConditionSelector.tsx
+++ b/frontend/src/features/meeting/components/conditionSelector/ConditionSelector.tsx
@@ -31,6 +31,7 @@ function ConditionSelector({
             key={condition.ID}
             iconText={condition.ICON}
             contentText={condition.TEXT}
+            descriptionText={condition.DESCRIPTION}
             isSelected={selectedConditionIDs.includes(condition.ID)}
             onClick={() => handleConditionCardClick(condition.ID)}
           />

--- a/frontend/src/features/meeting/components/conditionSelector/ConditionSelector.tsx
+++ b/frontend/src/features/meeting/components/conditionSelector/ConditionSelector.tsx
@@ -7,12 +7,12 @@ import InputFormSection from '../meetingFormSection/MeetingFormSection';
 import * as conditionSelector from './conditionSelector.styled';
 
 interface ConditionSelectorProps {
-  selectedConditionID: string;
+  selectedConditionIDs: string[];
   onSelect: (condition: string) => void;
 }
 
 function ConditionSelector({
-  selectedConditionID,
+  selectedConditionIDs,
   onSelect,
 }: ConditionSelectorProps) {
   const handleConditionCardClick = (condition: string) => {
@@ -30,7 +30,7 @@ function ConditionSelector({
             key={condition.ID}
             iconText={condition.ICON}
             contentText={condition.TEXT}
-            isSelected={selectedConditionID === condition.ID}
+            isSelected={selectedConditionIDs.includes(condition.ID)}
             onClick={() => handleConditionCardClick(condition.ID)}
           />
         ))}

--- a/frontend/src/features/meeting/components/conditionSelector/conditionSelector.stories.ts
+++ b/frontend/src/features/meeting/components/conditionSelector/conditionSelector.stories.ts
@@ -12,9 +12,9 @@ const meta = {
   },
   tags: ['autodocs'],
   argTypes: {
-    selectedConditionID: {
-      control: { type: 'text' },
-      description: '조건 ID',
+    selectedConditionIDs: {
+      control: { type: 'object' },
+      description: '선택된 조건 ID들',
     },
     onSelect: {
       description: '조건 ID 업데이트 시 실행될 함수',
@@ -27,7 +27,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    selectedConditionID: '',
+    selectedConditionIDs: [],
     onSelect: () => {},
   },
 };

--- a/frontend/src/features/meeting/components/conditionSelector/conditionSelector.stories.ts
+++ b/frontend/src/features/meeting/components/conditionSelector/conditionSelector.stories.ts
@@ -31,3 +31,10 @@ export const Default: Story = {
     onSelect: () => {},
   },
 };
+
+export const WithSelectedConditions: Story = {
+  args: {
+    selectedConditionIDs: ['CAFE', 'RESTAURANT'],
+    onSelect: () => {},
+  },
+};

--- a/frontend/src/features/meeting/components/departureInput/DepartureInput.tsx
+++ b/frontend/src/features/meeting/components/departureInput/DepartureInput.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import InputFormSection from '@features/meeting/components/meetingFormSection/MeetingFormSection';
+import MeetingFormSection from '@features/meeting/components/meetingFormSection/MeetingFormSection';
 import { INPUT_FORM_TEXT } from '@features/meeting/constants/inputForm';
 import { STATION_LIST } from '@features/meeting/constants/stationList';
 
@@ -60,7 +60,8 @@ function DepartureInput({
   };
 
   return (
-    <InputFormSection
+    <MeetingFormSection
+      iconText={INPUT_FORM_TEXT.DEPARTURE.ICON}
       titleText={INPUT_FORM_TEXT.DEPARTURE.TITLE}
       descriptionText={INPUT_FORM_TEXT.DEPARTURE.DESCRIPTION}
     >
@@ -88,7 +89,7 @@ function DepartureInput({
           />
         ))}
       </div>
-    </InputFormSection>
+    </MeetingFormSection>
   );
 }
 

--- a/frontend/src/features/meeting/components/meetingForm/MeetingForm.tsx
+++ b/frontend/src/features/meeting/components/meetingForm/MeetingForm.tsx
@@ -21,7 +21,7 @@ function MeetingForm() {
 
   const {
     departureList,
-    conditionID,
+    conditionIDs,
     addDepartureWithValidation,
     removeDepartureAtIndex,
     updateConditionID,
@@ -33,7 +33,7 @@ function MeetingForm() {
 
   const isValid = React.useMemo(
     () => validateFormSubmit().isValid,
-    [departureList, conditionID],
+    [departureList, conditionIDs],
   );
 
   const showValidationError = (error: ValidationError) => {
@@ -62,7 +62,7 @@ function MeetingForm() {
     try {
       const { id } = await getRecommendationFull({
         startingPlaceNames: departureList,
-        requirement: conditionID,
+        requirements: conditionIDs,
       });
 
       if (id) navigate(`/result/${id}`);
@@ -70,7 +70,7 @@ function MeetingForm() {
       showToast('모임 지역 찾기에 실패했습니다.');
     }
 
-    setMeetingStorage({ departureList, conditionID });
+    setMeetingStorage({ departureList, conditionIDs });
   };
 
   return (
@@ -83,7 +83,7 @@ function MeetingForm() {
         />
 
         <ConditionSelector
-          selectedConditionID={conditionID}
+          selectedConditionIDs={conditionIDs}
           onSelect={updateConditionID}
         />
       </div>

--- a/frontend/src/features/meeting/components/meetingFormSection/MeetingFormSection.tsx
+++ b/frontend/src/features/meeting/components/meetingFormSection/MeetingFormSection.tsx
@@ -5,12 +5,14 @@ import { flex, typography } from '@shared/styles/default.styled';
 import * as section from './meetingFormSection.styled';
 
 interface MeetingFormSectionProps {
+  iconText: string;
   titleText: string;
   descriptionText: string;
   children: React.ReactNode;
 }
 
 function MeetingFormSection({
+  iconText,
   titleText,
   descriptionText,
   children,
@@ -18,7 +20,10 @@ function MeetingFormSection({
   return (
     <div css={flex({ direction: 'column', gap: 10 })}>
       <div css={[flex({ direction: 'column', gap: 8 }), section.header()]}>
-        <span css={[typography.h2, section.title()]}>{titleText}</span>
+        <div css={[flex({ gap: 2 })]}>
+          <span css={[typography.sh1, section.icon()]}>{iconText}</span>
+          <span css={[typography.h2, section.title()]}>{titleText}</span>
+        </div>
         <span css={[typography.b2, section.description()]}>
           {descriptionText}
         </span>

--- a/frontend/src/features/meeting/components/meetingFormSection/meetingFormSection.styled.ts
+++ b/frontend/src/features/meeting/components/meetingFormSection/meetingFormSection.styled.ts
@@ -6,6 +6,10 @@ export const header = () => css`
   padding-left: 10px;
 `;
 
+export const icon = () => css`
+  font-family: 'Tossface';
+`;
+
 export const title = () => css`
   color: ${colorToken.gray[2]};
 `;

--- a/frontend/src/features/meeting/constants/conditionCard.ts
+++ b/frontend/src/features/meeting/constants/conditionCard.ts
@@ -6,33 +6,51 @@ type ConditionCardText = Record<
     ID: LocationRequirement;
     ICON: string;
     TEXT: string;
+    DESCRIPTION?: string;
   }
 >;
 
 export const CONDITION_CARD_TEXT: ConditionCardText = {
-  CHAT: {
-    ID: 'CHAT',
-    ICON: '💬',
-    TEXT: '떠들고 놀기 좋은',
+  CAFE: {
+    ID: 'CAFE',
+    ICON: '☕',
+    TEXT: '카페',
   },
-  MEETING: {
-    ID: 'MEETING',
-    ICON: '🎤',
-    TEXT: '회의하기 좋은',
+  RESTAURANT: {
+    ID: 'RESTAURANT',
+    ICON: '🍴',
+    TEXT: '식당',
   },
-  FOCUS: {
-    ID: 'FOCUS',
-    ICON: '📖',
-    TEXT: '집중하기 좋은',
+  BAR: {
+    ID: 'BAR',
+    ICON: '🍺',
+    TEXT: '술집',
   },
-  DATE: {
-    ID: 'DATE',
-    ICON: '💝',
-    TEXT: '데이트하기 좋은',
+  STUDY_CAFE: {
+    ID: 'STUDY_CAFE',
+    ICON: '📚',
+    TEXT: '스터디카페',
   },
-  NOT_SELECTED: {
-    ID: 'NOT_SELECTED',
-    ICON: '✅',
-    TEXT: '선택하지 않음',
+  SPACE_RENTAL: {
+    ID: 'SPACE_RENTAL',
+    ICON: '🎉',
+    TEXT: '파티룸',
+  },
+  PC_ROOM_KARAOKE: {
+    ID: 'PC_ROOM_KARAOKE',
+    ICON: '🎮',
+    TEXT: 'PC방/노래방',
+  },
+  ACTIVITY: {
+    ID: 'ACTIVITY',
+    ICON: '🤾',
+    TEXT: '액티비티',
+    DESCRIPTION: '클라이밍,볼링,사격,당구',
+  },
+  ENTERTAINMENT: {
+    ID: 'ENTERTAINMENT',
+    ICON: '🍿',
+    TEXT: '엔터테인먼트',
+    DESCRIPTION: '방탈출,만화방,보드게임카페,영화관',
   },
 };

--- a/frontend/src/features/meeting/constants/conditionCard.ts
+++ b/frontend/src/features/meeting/constants/conditionCard.ts
@@ -13,7 +13,7 @@ type ConditionCardText = Record<
 export const CONDITION_CARD_TEXT: ConditionCardText = {
   CAFE: {
     ID: 'CAFE',
-    ICON: '☕',
+    ICON: '☕️',
     TEXT: '카페',
   },
   RESTAURANT: {

--- a/frontend/src/features/meeting/constants/inputForm.ts
+++ b/frontend/src/features/meeting/constants/inputForm.ts
@@ -1,10 +1,12 @@
 export const INPUT_FORM_TEXT = {
   DEPARTURE: {
-    TITLE: '📍 모임 참여자들의 출발지를 입력해주세요',
-    DESCRIPTION: '서울 내의 지하철역을 기준으로 2곳 이상 입력해야해요',
+    ICON: '📍',
+    TITLE: '모임 참여자들의 출발지를 입력해 주세요',
+    DESCRIPTION: '수도권 내의 지하철역을 2개 이상 6개 이하로 입력해야 해요',
   },
   CONDITION: {
-    TITLE: '📍 만날 지역에 대한 조건을 선택해주세요',
-    DESCRIPTION: '모임 장소를 고려하기 위한 조건을 선택해주세요',
+    ICON: '📍',
+    TITLE: '모임에 대한 목적을 선택해 주세요',
+    DESCRIPTION: '중복선택이 가능해요',
   },
 } as const;

--- a/frontend/src/features/meeting/hooks/useFormInfo.ts
+++ b/frontend/src/features/meeting/hooks/useFormInfo.ts
@@ -14,7 +14,7 @@ import { ValidationError } from '@shared/types/validationError';
 
 type UseFormInfoReturn = {
   departureList: string[];
-  conditionID: LocationRequirement;
+  conditionIDs: LocationRequirement[];
   addDepartureWithValidation: (departure: string) => ValidationError;
   removeDepartureAtIndex: (index: number) => void;
   updateConditionID: (condition: LocationRequirement) => void;
@@ -26,8 +26,8 @@ export function useFormInfo(): UseFormInfoReturn {
   const [departureList, setDepartureList] = useState<string[]>(
     storage.departureList,
   );
-  const [conditionID, setConditionID] = useState<LocationRequirement>(
-    storage.conditionID,
+  const [conditionIDs, setConditionIDs] = useState<LocationRequirement[]>(
+    storage.conditionIDs,
   );
 
   const addDepartureWithValidation = (departure: string): ValidationError => {
@@ -60,16 +60,21 @@ export function useFormInfo(): UseFormInfoReturn {
   };
 
   const updateConditionID = (condition: LocationRequirement) => {
-    setConditionID(condition);
+    setConditionIDs((prev) => {
+      if (prev.includes(condition)) {
+        return prev.filter((id) => id !== condition);
+      }
+      return [...prev, condition];
+    });
   };
 
   const validateFormSubmit = (): ValidationError => {
-    return validateForm(departureList, conditionID);
+    return validateForm(departureList, conditionIDs);
   };
 
   return {
     departureList,
-    conditionID,
+    conditionIDs,
     addDepartureWithValidation,
     removeDepartureAtIndex,
     updateConditionID,

--- a/frontend/src/features/meeting/lib/formValidation.ts
+++ b/frontend/src/features/meeting/lib/formValidation.ts
@@ -72,7 +72,7 @@ export const validateDuplicateDeparture = (
 
 export const validateForm = (
   departureList: string[],
-  conditionId: string,
+  conditionIds: string[],
 ): ValidationError => {
   const minLengthValidation = validateDepartureListMinLength(
     departureList.length,
@@ -81,7 +81,7 @@ export const validateForm = (
     return minLengthValidation;
   }
 
-  if (!conditionId) {
+  if (conditionIds.length === 0) {
     return {
       isValid: false,
       message: '조건을 선택해주세요',

--- a/frontend/src/features/recommendation/components/bottomSheet/BottomSheet.tsx
+++ b/frontend/src/features/recommendation/components/bottomSheet/BottomSheet.tsx
@@ -19,7 +19,7 @@ interface BottomSheetProps {
   startingLocations: StartingPlace[];
   recommendedLocations: RecommendedLocation[];
   selectedLocation: SelectedLocation;
-  conditionID: LocationRequirement;
+  conditionIDs: LocationRequirement[];
   handleSpotClick: (spot: RecommendedLocation) => void;
 }
 
@@ -27,7 +27,7 @@ function BottomSheet({
   startingLocations,
   recommendedLocations,
   selectedLocation,
-  conditionID,
+  conditionIDs,
   handleSpotClick,
 }: BottomSheetProps) {
   const [positionPercent, setPositionPercent] = useState(60);
@@ -144,7 +144,7 @@ function BottomSheet({
         <BottomSheetList
           startingPlaces={startingLocations}
           recommendedLocations={recommendedLocations}
-          conditionID={conditionID}
+          conditionIDs={conditionIDs}
           onSpotClick={handleSpotClick}
         />
       )}

--- a/frontend/src/features/recommendation/components/bottomSheet/bottomSheet.stories.ts
+++ b/frontend/src/features/recommendation/components/bottomSheet/bottomSheet.stories.ts
@@ -43,7 +43,7 @@ export const Default: Story = {
   args: {
     startingLocations: StartingPlacesMock,
     recommendedLocations: RecommendedLocationsMock,
-    conditionID: 'NOT_SELECTED',
+    conditionIDs: ['CAFE'],
     selectedLocation: null,
     handleSpotClick: () => {},
   },
@@ -53,7 +53,7 @@ export const Short: Story = {
   args: {
     startingLocations: StartingPlacesMock,
     recommendedLocations: RecommendedLocationsMock.slice(0, 2),
-    conditionID: 'NOT_SELECTED',
+    conditionIDs: ['CAFE'],
     selectedLocation: null,
     handleSpotClick: () => {},
   },

--- a/frontend/src/features/recommendation/components/bottomSheetDetail/BottomSheetDetail.tsx
+++ b/frontend/src/features/recommendation/components/bottomSheetDetail/BottomSheetDetail.tsx
@@ -62,9 +62,11 @@ function BottomSheetDetail({
 
       <DetailSection isHeader={false} title={'추천 장소'} isBestBadge={false}>
         <div css={[flex(), scroll, bottomSheetDetail.placeList()]}>
-          {selectedLocation.places.map((place) => (
-            <PlaceCard key={place.index} place={place} />
-          ))}
+          {Object.keys(selectedLocation.places).map((category) =>
+            selectedLocation.places[category].map((place) => (
+              <PlaceCard key={place.index} place={place} />
+            )),
+          )}
         </div>
       </DetailSection>
     </div>

--- a/frontend/src/features/recommendation/components/bottomSheetList/BottomSheetList.tsx
+++ b/frontend/src/features/recommendation/components/bottomSheetList/BottomSheetList.tsx
@@ -11,21 +11,21 @@ import SpotItemList from '../spotItemList/SpotItemList';
 interface BottomSheetListProps {
   startingPlaces: StartingPlace[];
   recommendedLocations: RecommendedLocation[];
-  conditionID: LocationRequirement;
+  conditionIDs: LocationRequirement[];
   onSpotClick: (spot: RecommendedLocation) => void;
 }
 
 function BottomSheetList({
   startingPlaces,
   recommendedLocations,
-  conditionID,
+  conditionIDs,
   onSpotClick,
 }: BottomSheetListProps) {
   return (
     <>
       <MeetingWrapper
         startingPlaces={startingPlaces}
-        conditionID={conditionID}
+        conditionIDs={conditionIDs}
       />
       <SpotItemList
         recommendedLocations={recommendedLocations}

--- a/frontend/src/mocks/LocationsMock.ts
+++ b/frontend/src/mocks/LocationsMock.ts
@@ -69,7 +69,7 @@ export const RecommendedLocationsMock: RecommendedLocation[] = [
 ];
 
 export const LocationsMock: LocationResponse = {
-  requirement: 'FOCUS',
+  requirements: ['CAFE', 'STUDY_CAFE'],
   startingPlaces: [
     {
       id: 1,

--- a/frontend/src/mocks/LocationsRequestBodyMock.ts
+++ b/frontend/src/mocks/LocationsRequestBodyMock.ts
@@ -2,5 +2,5 @@ import { RecommendationRequestBody } from '@entities/location/api/types/Recommen
 
 export const LocationsRequestBodyMock: RecommendationRequestBody = {
   startingPlaceNames: ['강변역', '동대문역', '서울대입구역'],
-  requirement: 'CHAT',
+  requirements: ['CAFE', 'RESTAURANT'],
 };

--- a/frontend/src/pages/resultPage/ResultPage.tsx
+++ b/frontend/src/pages/resultPage/ResultPage.tsx
@@ -86,7 +86,7 @@ function ResultPage() {
         <BottomSheet
           startingLocations={location.startingPlaces}
           recommendedLocations={location.recommendedLocations}
-          conditionID={location.requirement}
+          conditionIDs={location.requirements}
           selectedLocation={selectedLocation}
           handleSpotClick={handleSpotClick}
         />

--- a/frontend/src/shared/components/meetingWrapper/MeetingWrapper.tsx
+++ b/frontend/src/shared/components/meetingWrapper/MeetingWrapper.tsx
@@ -10,19 +10,21 @@ import * as meetingWrapper from './meetingWrapper.styled';
 
 interface StaringSpotWrapperProps {
   startingPlaces: StartingPlace[];
-  conditionID: LocationRequirement;
+  conditionIDs: LocationRequirement[];
 }
 
 const getCustomConditionIdText = (id: LocationRequirement) => {
   const entry = CONDITION_CARD_TEXT[id];
-  return entry.ID === 'NOT_SELECTED' ? entry.TEXT : `${entry.TEXT} 장소`;
+  return `${entry.TEXT}`;
 };
 
 function MeetingWrapper({
   startingPlaces,
-  conditionID,
+  conditionIDs,
 }: StaringSpotWrapperProps) {
-  const conditionIdText = getCustomConditionIdText(conditionID);
+  const conditionIdTexts = conditionIDs.map((id) =>
+    getCustomConditionIdText(id),
+  );
 
   return (
     <div css={[meetingWrapper.base(), flex({ direction: 'column', gap: 10 })]}>
@@ -43,9 +45,13 @@ function MeetingWrapper({
       </div>
       <div css={[flex({ align: 'center', gap: 10 })]}>
         <span css={[typography.sh1, meetingWrapper.title()]}>조건</span>
-        <span css={[typography.b2, meetingWrapper.content()]}>
-          {conditionIdText}
-        </span>
+        <div css={[flex({ wrap: 'wrap', gap: 5 })]}>
+          {conditionIdTexts.map((text, index) => (
+            <span key={index} css={[typography.b2, meetingWrapper.content()]}>
+              {text}
+            </span>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/shared/components/meetingWrapper/meetingWrapper.stories.ts
+++ b/frontend/src/shared/components/meetingWrapper/meetingWrapper.stories.ts
@@ -23,10 +23,9 @@ const meta = {
       control: { type: 'object' },
       description: '출발지 이름 목록',
     },
-    conditionID: {
-      control: { type: 'select' },
-      options: conditionIdList,
-      description: '출발지 조건',
+    conditionIDs: {
+      control: { type: 'object' },
+      description: '출발지 조건들',
     },
   },
 } satisfies Meta<typeof MeetingWrapper>;
@@ -37,7 +36,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     startingPlaces: StartingPlacesMock,
-    conditionID: 'CHAT',
+    conditionIDs: ['CAFE'],
   },
 };
 
@@ -61,6 +60,6 @@ export const Long: Story = {
       { index: 14, name: '을지로5가역', id: 14, x: 14, y: 14 },
       { index: 15, name: '을지로6가역', id: 15, x: 15, y: 15 },
     ],
-    conditionID: 'CHAT',
+    conditionIDs: ['CAFE'],
   },
 };

--- a/frontend/src/shared/components/meetingWrapper/meetingWrapper.stories.ts
+++ b/frontend/src/shared/components/meetingWrapper/meetingWrapper.stories.ts
@@ -8,9 +8,6 @@ import MeetingWrapper from './MeetingWrapper';
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
-const conditionIdList = Object.values(CONDITION_CARD_TEXT).map(
-  (condition) => condition.ID,
-);
 const meta = {
   component: MeetingWrapper,
   decorators: [withContainer],

--- a/frontend/src/shared/components/meetingWrapper/meetingWrapper.stories.ts
+++ b/frontend/src/shared/components/meetingWrapper/meetingWrapper.stories.ts
@@ -1,5 +1,3 @@
-import { CONDITION_CARD_TEXT } from '@features/meeting/constants/conditionCard';
-
 import { StartingPlacesMock } from '@mocks/LocationsMock';
 
 import { withContainer } from '@sb/decorators/withContainer';

--- a/frontend/src/shared/styles/GlobalStyle.tsx
+++ b/frontend/src/shared/styles/GlobalStyle.tsx
@@ -12,6 +12,15 @@ function GlobalStyle() {
         styles={css`
           * {
             font-family: 'Pretendard';
+            font-family:
+              'Pretendard',
+              -apple-system,
+              BlinkMacSystemFont,
+              'Segoe UI',
+              Roboto,
+              'Helvetica Neue',
+              Arial,
+              sans-serif;
           }
         `}
       />

--- a/frontend/src/shared/styles/GlobalStyle.tsx
+++ b/frontend/src/shared/styles/GlobalStyle.tsx
@@ -5,13 +5,22 @@ function GlobalStyle() {
   return (
     <>
       <link
-        href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
+        rel="preconnect"
+        href="https://cdn.jsdelivr.net"
+        crossOrigin="anonymous"
+      />
+      <link
         rel="stylesheet"
+        href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
+      />
+      <link
+        href="https://cdn.jsdelivr.net/gh/toss/tossface/dist/tossface.css"
+        rel="stylesheet"
+        type="text/css"
       />
       <Global
         styles={css`
           * {
-            font-family: 'Pretendard';
             font-family:
               'Pretendard',
               -apple-system,

--- a/frontend/src/shared/styles/reset.css
+++ b/frontend/src/shared/styles/reset.css
@@ -160,7 +160,3 @@ input::-webkit-inner-spin-button {
 a {
   text-decoration: none;
 }
-
-body {
-  font-family: 'Noto Sans', sans-serif;
-}


### PR DESCRIPTION
# #️⃣ Issue Number

#448 

## 🕹️ 작업 내용

한 줄 요약 : 모임 폼 컴포넌트 UI 개선 및 폰트 최적화

Files Changed가 많아서 놀라셨겠지만, 이전 PR에 이어서 작업해서 그런 것입니다 😂
사실 변경사항은 많이 없습니다. Commit을 깔끔하게 정리해서 진행했으니 Commit 내역을 따라가시는 걸 추천합니다!

- [x] Tossface 이모지 폰트 적용 및 최적화
- [x] 폰트 관리 구조 개선 (reset.css → GlobalStyle.tsx)
- [x] 조건 카드에 설명 UI 추가 (엔터테인먼트, 액티비티 등)
- [x] 컴포넌트 이름 통일 (InputFormSection → MeetingFormSection)

## 📋 리뷰 포인트

- UI/UX: 변경된 디자인과 동일하게 UI/UX가 반영됐나요?
  - [ ] IndexPage 문구가 적절히 변경 되었는지 확인
  - [ ] 조건 카드의 설명 텍스트가 적절히 표시되고 있는지 확인
  - [ ] 조건 카드의 이모지가 적절히 표시되고 있는지 확인
- 폰트 최적화:  Pretendard 폰트가 적용되지 않을시 기본 폰트를 보여주고 있나요?
  - [ ]  GlobalStyle.tsx에서 폰트 fallback 체인이 올바르게 적용되었는지 확인 
- 컴포넌트 구조: 이상하게 MeetingFormSection 컴포넌트를 외부에서 사용할 때 InputFormSection로 사용하더라고요, 이를 MeetingFormSection로 바꿨는데 정상적으로 동작하는지 확인해주세요 9c1b60c364e72c4a0ce9cd1d6dba50bf748f0ba9
  - [ ] MeetingFormSection으로 이름 통일 후 모든 참조가 올바르게 업데되었는지 확인

## 🔮 [질문] 폰트 FOUT, FOIT 현상 / 어떤 걸 선택해야 할까?

| FOIT | FOUT |
|------|------|
| ![FOUT현상](https://github.com/user-attachments/assets/ed9baeb4-55c1-40a4-96be-94b298662925) | ![FOIT현상](https://github.com/user-attachments/assets/f0c51ba7-91a1-44f7-a641-58d6c881953a)|

위 영상과 같이 폰트를 불러올 때 FOUT, FOIT 현상이 발생할 수 있습니다.  이 현상이 발생하는 이유는 렌더링 과정에서 폰트가 다운로드 되지 않았기 때문입니다. 

FOUT는 로컬 폰트를 먼저 보여주고, 폰트가 다운로드 되면 적용된 폰트를 보여줍니다.
FOIT는 로컬 폰트를 보여주지 않고, 폰트가 다운로드 되면 적용된 폰트를 보여줍니다.

현재는 FOIT 현상이 발생하도록 구현된 상태인데요, **FOUT 현상으로 폰트를 불러오는게 더 자연스러우면 수정 가능합니다.**

각 방식을 비교해보겠습니다.

- FOUT 방식
  - 텍스트 렌더링이 빠르다는 장점이 있지만 폰트가 교체되는 시점에 깜빡임이 발생하거나, 줄간격/자간 차이의 누적으로 Layout Shift가 발생할 수 있다. 
- FOIT 방식
  - 렌더링 시점이 상대적으로 늦기 때문에 LCP/FCP 등의 지표 개선 및 불안정한 네트워크 환경에 대한 대처가 힘들다.

추가로, 이와 별개로 subset, dynamic subset 같은 최적화 방식도 추천해주시면 고려해보겠습니다.

## 🔮 [공유] 현재 토스 폰트에 적용된 최적화 방법은?

처음에는 폰트 파일을 직접 다운로드해 로컬에 저장 후 불러오는 방식으로 진행했습니다.
토스에서 제공하는 기본 폰트(`ttf`)를 그대로 사용했을 때, Fase4G 환경에서 로딩에 약 12초가 걸렸습니다.

그래서 추가적인 최적화가 필요하다고 느꼈고,
[공식 문서: 토스 폰트 최적화](https://github.com/toss/tossface/blob/main/dist/tossface.css)를 참고해 개선을 진행했습니다.
현재는 Fase4G 환경에서도 최대 3초 이내로 폰트가 로드됩니다. 👇

<img width="716" height="194" alt="pre-before" src="https://github.com/user-attachments/assets/b8b47d7d-9b11-47a2-8e98-48b0e4b31945" />

### 🔧 최적화 방법

- 폰트 포맷 변경 (`.ttf → .woff2`) 
  - `.woff2`는 더 효율적인 압축을 제공하여 파일 크기를 줄이고, 브라우저가 폰트를 더 빠르게 불러올 수 있습니다.
  - 외부에서 불러오는 파일인 `tossface.css` 안에 있는 내용입니다.
- 부분 로딩 (Subsetting) 적용
  - 하나의 큰 폰트 파일을 여러 개의 작은 `.woff2` 파일로 나누어,
    먼저 로드된 폰트부터 바로 화면에 적용되도록 했습니다.
  - 외부에서 불러오는 파일인 `tossface.css` 안에 있는 내용입니다.
- Preconnect 추가
  - 초기 연결 지연을 줄이기 위해 CDN 서버에 미리 연결했습니다.
  - Fast4G 환경에서 큰 차이는 없었지만, 네트워크 상황에 따라 도움이 될 것으로 예상됩니다.

## 🍿 [공유 - 필수 아님] preload가 폰트 로딩을 느리게 만든 이유

처음에는 TossFace 폰트를 도입하며 “가장 먼저 보여야 하니까 preload로 불러오자”는 판단을 했습니다. 하지만 실제로는 preload 적용 시 로딩 속도가 약 2배 느려졌습니다.

- preload 적용 전
  - <img width="716" height="194" alt="pre-before" src="https://github.com/user-attachments/assets/a5fe9849-59e1-417c-8292-b95eb1cd8049" />
- prelaod 적용 후
  - <img width="723" height="201" alt="pre-after" src="https://github.com/user-attachments/assets/ae866a4a-d50a-4796-b196-1530d9241bc0" />

“다운로드를 앞당겼는데 왜 느려질까?”를 분석해보니, 이유는 다음과 같습니다.

- 시작 시점은 빨라지지만, 전체 시간은 단축되지 않음
  - preload는 “먼저 시작”일 뿐, “빨리 끝난다”는 보장이 없습니다.
- 리소스 간 경합 발생
  - preload 없이: HTML → CSS → JS → 폰트 (순차적, 안정적)
  - preload 사용 시: HTML + CSS + JS + 폰트 (동시 요청, 대역폭 분산)
- 브라우저 우선순위 혼란
  - 모든 폰트가 높은 우선순위를 가지면 HTML/CSS 파싱이 지연될 수 있습니다.
- 개발 서버 및 연결 제한 영향
   - 로컬 서버의 동시 처리 한계

따라서 preload는 "무조건 빠르게 만드는" 속성이 아니라는 걸 꺠달았습니다.
경합 상황에서는 오히려 전체 로딩이 느려질 수 있다는 점,
그래서 정말 필요한 핵심 리소스에만 선택적으로 사용하는 것이 좋다는 점도 알게 되었습니다.

## 🍿 참고자료

[수이의 폰트 최적화 테코톡 문서](https://witty-horn-ec4.notion.site/274a6d4c8369805f8ef1d3253ed383d2)
