### PR TITLE
[FE] refactor: NAVER 지도 저작권 표기에서 축적 제거

### DIFF
--- a/frontend/src/features/map/hooks/useCustomOverlays.tsx
+++ b/frontend/src/features/map/hooks/useCustomOverlays.tsx
@@ -1,14 +1,6 @@
 /* eslint-disable no-undef */
 import { useEffect, useRef } from 'react';
 
-type NaverMapOptions = {
-  center: naver.maps.LatLng;
-  zoom: number;
-  scaleControl?: boolean;
-  logoControl?: boolean;
-  mapDataControl?: boolean;
-};
-
 import {
   createCustomOverlay,
   type CustomOverlayInstance,
@@ -30,6 +22,14 @@ interface UseCustomOverlaysProps {
   selectedLocation: RecommendedLocation | null;
   changeSelectedLocation: (loc: RecommendedLocation) => void;
 }
+
+type NaverMapOptions = {
+  center: naver.maps.LatLng;
+  zoom: number;
+  scaleControl?: boolean;
+  logoControl?: boolean;
+  mapDataControl?: boolean;
+};
 
 /* ===========================================
  * useCustomOverlays

--- a/frontend/src/features/map/hooks/useCustomOverlays.tsx
+++ b/frontend/src/features/map/hooks/useCustomOverlays.tsx
@@ -1,6 +1,14 @@
 /* eslint-disable no-undef */
 import { useEffect, useRef } from 'react';
 
+type NaverMapOptions = {
+  center: naver.maps.LatLng;
+  zoom: number;
+  scaleControl?: boolean;
+  logoControl?: boolean;
+  mapDataControl?: boolean;
+};
+
 import {
   createCustomOverlay,
   type CustomOverlayInstance,
@@ -60,10 +68,15 @@ export const useCustomOverlays = ({
       );
       const center = new naver.maps.LatLng(centerCoord.y - 0.1, centerCoord.x);
 
-      naverMapRef.current = new naver.maps.Map(mapRef.current, {
+      const mapOptions: NaverMapOptions = {
         center,
         zoom: 11,
-      });
+        scaleControl: false,
+        logoControl: false,
+        mapDataControl: false,
+      };
+
+      naverMapRef.current = new naver.maps.Map(mapRef.current, mapOptions);
     }
 
     // 기존 오버레이 제거

--- a/frontend/src/features/recommendation/components/bottomSheetView/bottomSheetView.styled.ts
+++ b/frontend/src/features/recommendation/components/bottomSheetView/bottomSheetView.styled.ts
@@ -10,6 +10,7 @@ export const base = () => css`
   left: 0;
   right: 0;
   bottom: 0;
+  z-index: 100;
 `;
 
 export const container = (positionPercent: number) => css`


### PR DESCRIPTION
# #️⃣ Issue Number
#466 

## 🕹️ 작업 내용

한 줄 요약 : NAVER 지도 저작권 표기에서 축적을 제거했어요

- NaverMapOptions 타입을 설정
- useCustomOverlays 훅의 map을 NaverMapOptions 타입으로 초기화하여 네이버 지도의 축적 제거

## 📋 리뷰 포인트

- [ ] 로컬에서 네이버 지도의 축적이 안 보이는지 확인해주세요.
- [ ] 축적을 지우는 다른 해결 방안이 있다면 피드백 부탁드립니다 !

## 🔮 기타 사항

- 네이버 지도 서비스 이용약관에 따라 저작권 표시를 완전히 제거하는 것은 법적 문제가 될 수 있어서 완전히 삭제하지 않았어요


## 📸 Before/After
| Before | After |
|-----|-----|
| <img width="396" height="826" alt="스크린샷 2025-10-21 오후 1 00 10" src="https://github.com/user-attachments/assets/fb7d50a1-54de-4959-9425-a8eb1f68e8a0" />  | <img width="391" height="826" alt="스크린샷 2025-10-21 오후 1 00 57" src="https://github.com/user-attachments/assets/9dfdd3c0-bc3d-4f59-acef-d9b2eb70c2df" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 지도 설정 코드 구조를 개선하여 유지보수성을 향상했습니다.
  * 지도 제어 옵션을 명시적으로 구성하여 코드 안정성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->