### PR TITLE
[BE] feat: 다중 카테고리 장소 검색 병렬화

### DIFF
--- a/backend/src/main/java/com/f12/moitz/application/RecommendationService.java
+++ b/backend/src/main/java/com/f12/moitz/application/RecommendationService.java
@@ -76,7 +76,6 @@ public class RecommendationService {
 
         stopWatch.start("지역 추천");
         final List<RecommendCondition> recommendConditions = RecommendCondition.fromTitle(request.requirements());
-        final List<String> requirements = RecommendCondition.getRequirements(recommendConditions);
         final List<SubwayStation> startingPlaces = getByNames(request.startingPlaceNames());
         final List<SubwayStation> candidatePlaces = subwayStationService.generateCandidatePlace(startingPlaces);
 
@@ -86,7 +85,7 @@ public class RecommendationService {
         final RecommendedLocationsResponse recommendedLocationsResponse = locationRecommender.recommendLocations(
                 startingPlaceNames,
                 candidatePlaceNames,
-                requirements
+                recommendConditions
         );
         final Map<Place, ReasonAndDescription> generatedPlacesWithReason = recommendedLocationsResponse.recommendations()
                 .stream()
@@ -116,7 +115,7 @@ public class RecommendationService {
         stopWatch.start("장소 추천");
         final Map<Place, CategorizedRecommendedPlaces> recommendedPlaces = asyncPlaceRecommender.recommendPlacesAsync(
                 generatedPlaces,
-                requirements
+                recommendConditions
         ).block();
         stopWatch.stop();
 

--- a/backend/src/main/java/com/f12/moitz/application/RecommendationService.java
+++ b/backend/src/main/java/com/f12/moitz/application/RecommendationService.java
@@ -125,7 +125,8 @@ public class RecommendationService {
                 recommendedPlaces,
                 placeRoutes,
                 placeCourses,
-                STARTING_VOTES
+                STARTING_VOTES,
+                recommendConditions
         );
         stopWatch.stop();
         log.debug("추천 서비스 완료. {}", stopWatch.shortSummary());

--- a/backend/src/main/java/com/f12/moitz/application/RecommendationService.java
+++ b/backend/src/main/java/com/f12/moitz/application/RecommendationService.java
@@ -4,6 +4,7 @@ import com.f12.moitz.application.dto.RecommendationCreateResponse;
 import com.f12.moitz.application.dto.RecommendationRequest;
 import com.f12.moitz.application.dto.RecommendationResultResponse;
 import com.f12.moitz.application.dto.RecommendedLocationsResponse;
+import com.f12.moitz.application.port.AsyncPlaceRecommender;
 import com.f12.moitz.application.port.LocationRecommender;
 import com.f12.moitz.application.port.PlaceRecommender;
 import com.f12.moitz.application.port.RouteFinder;
@@ -45,6 +46,7 @@ public class RecommendationService {
 
     private final SubwayStationService subwayStationService;
     private final PlaceRecommender placeRecommender;
+    private final AsyncPlaceRecommender asyncPlaceRecommender;
     private final LocationRecommender locationRecommender;
     private final RouteFinder routeFinder;
     private final RecommendationMapper recommendationMapper;
@@ -53,6 +55,7 @@ public class RecommendationService {
     public RecommendationService(
             @Autowired final SubwayStationService subwayStationService,
             @Qualifier("placeRecommenderAdapter") final PlaceRecommender placeRecommender,
+            @Autowired final AsyncPlaceRecommender asyncPlaceRecommender,
             @Autowired final LocationRecommender locationRecommender,
             @Qualifier("subwayRouteFinderAdapter") final RouteFinder routeFinder,
             @Autowired final RecommendationMapper recommendationMapper,
@@ -60,6 +63,7 @@ public class RecommendationService {
     ) {
         this.subwayStationService = subwayStationService;
         this.placeRecommender = placeRecommender;
+        this.asyncPlaceRecommender = asyncPlaceRecommender;
         this.locationRecommender = locationRecommender;
         this.routeFinder = routeFinder;
         this.recommendationMapper = recommendationMapper;
@@ -110,10 +114,10 @@ public class RecommendationService {
         stopWatch.stop();
 
         stopWatch.start("장소 추천");
-        final Map<Place, CategorizedRecommendedPlaces> recommendedPlaces = placeRecommender.recommendPlaces(
+        final Map<Place, CategorizedRecommendedPlaces> recommendedPlaces = asyncPlaceRecommender.recommendPlacesAsync(
                 generatedPlaces,
                 requirements
-        );
+        ).block();
         stopWatch.stop();
 
         stopWatch.start("Recommendation으로 변환");

--- a/backend/src/main/java/com/f12/moitz/application/port/AsyncPlaceRecommender.java
+++ b/backend/src/main/java/com/f12/moitz/application/port/AsyncPlaceRecommender.java
@@ -2,6 +2,7 @@ package com.f12.moitz.application.port;
 
 import com.f12.moitz.domain.CategorizedRecommendedPlaces;
 import com.f12.moitz.domain.Place;
+import com.f12.moitz.domain.RecommendCondition;
 import java.util.List;
 import java.util.Map;
 import reactor.core.publisher.Mono;
@@ -10,7 +11,7 @@ public interface AsyncPlaceRecommender {
 
     Mono<Map<Place, CategorizedRecommendedPlaces>> recommendPlacesAsync(
             List<Place> targetPlaces,
-            List<String> requirements
+            List<RecommendCondition> requirements
     );
 
 }

--- a/backend/src/main/java/com/f12/moitz/application/port/AsyncPlaceRecommender.java
+++ b/backend/src/main/java/com/f12/moitz/application/port/AsyncPlaceRecommender.java
@@ -1,0 +1,16 @@
+package com.f12.moitz.application.port;
+
+import com.f12.moitz.domain.CategorizedRecommendedPlaces;
+import com.f12.moitz.domain.Place;
+import java.util.List;
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+public interface AsyncPlaceRecommender {
+
+    Mono<Map<Place, CategorizedRecommendedPlaces>> recommendPlacesAsync(
+            List<Place> targetPlaces,
+            List<String> requirements
+    );
+
+}

--- a/backend/src/main/java/com/f12/moitz/application/port/LocationRecommender.java
+++ b/backend/src/main/java/com/f12/moitz/application/port/LocationRecommender.java
@@ -1,6 +1,7 @@
 package com.f12.moitz.application.port;
 
 import com.f12.moitz.application.dto.RecommendedLocationsResponse;
+import com.f12.moitz.domain.RecommendCondition;
 import java.util.List;
 
 public interface LocationRecommender {
@@ -8,6 +9,6 @@ public interface LocationRecommender {
     RecommendedLocationsResponse recommendLocations(
             List<String> startingPlaces,
             List<String> candidatePlaces,
-            List<String> requirements
+            List<RecommendCondition> requirements
     );
 }

--- a/backend/src/main/java/com/f12/moitz/application/port/PlaceRecommender.java
+++ b/backend/src/main/java/com/f12/moitz/application/port/PlaceRecommender.java
@@ -2,11 +2,12 @@ package com.f12.moitz.application.port;
 
 import com.f12.moitz.domain.CategorizedRecommendedPlaces;
 import com.f12.moitz.domain.Place;
+import com.f12.moitz.domain.RecommendCondition;
 import java.util.List;
 import java.util.Map;
 
 public interface PlaceRecommender {
 
-    Map<Place, CategorizedRecommendedPlaces> recommendPlaces(List<Place> targetPlaces, List<String> requirements);
+    Map<Place, CategorizedRecommendedPlaces> recommendPlaces(List<Place> targetPlaces, List<RecommendCondition> requirements);
 
 }

--- a/backend/src/main/java/com/f12/moitz/application/utils/RecommendationMapper.java
+++ b/backend/src/main/java/com/f12/moitz/application/utils/RecommendationMapper.java
@@ -61,13 +61,22 @@ public class RecommendationMapper {
             final Map<Place, CategorizedRecommendedPlaces> placeListMap,
             final Map<Place, Routes> placeRoutes,
             final Map<Place, Courses> placeCourses,
-            final int votes
+            final int votes,
+            final List<RecommendCondition> recommendConditions
     ) {
         return new Recommendation(
                 generatedPlaces.entrySet().stream()
-                        // TODO: 카테고리 키워드 재정의 혹은 네이버 장소 추천 도입 고려
                         .filter(entry -> placeListMap.get(entry.getKey()) != null)
-                        .filter(entry -> !placeListMap.get(entry.getKey()).isEmpty())
+                        .filter(entry -> {
+                            Map<RecommendCondition, List<RecommendedPlace>> categoryMap =
+                                    placeListMap.get(entry.getKey()).getCategorizedPlaces();
+
+                            return recommendConditions.stream()
+                                    .allMatch(condition ->
+                                        categoryMap.containsKey(condition) &&
+                                        !categoryMap.get(condition).isEmpty()
+                                    );
+                        })
                         .map(place -> new Candidate(
                                 place.getKey(),
                                 placeRoutes.get(place.getKey()),

--- a/backend/src/main/java/com/f12/moitz/common/config/ClientConfig.java
+++ b/backend/src/main/java/com/f12/moitz/common/config/ClientConfig.java
@@ -35,6 +35,14 @@ public class ClientConfig {
     }
 
     @Bean
+    public WebClient kakaoWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://dapi.kakao.com/v2")
+                .clientConnector(new ReactorClientHttpConnector(httpClient(5)))
+                .build();
+    }
+
+    @Bean
     public RestClient odsayRestClient() {
         return restClientBuilder()
                 .baseUrl("https://api.odsay.com/v1/api")

--- a/backend/src/main/java/com/f12/moitz/domain/Result.java
+++ b/backend/src/main/java/com/f12/moitz/domain/Result.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import java.util.List;
 

--- a/backend/src/main/java/com/f12/moitz/infrastructure/adapter/LocationRecommenderAdapter.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/adapter/LocationRecommenderAdapter.java
@@ -4,6 +4,7 @@ import com.f12.moitz.application.dto.RecommendedLocationsResponse;
 import com.f12.moitz.application.port.LocationRecommender;
 import com.f12.moitz.common.error.exception.ExternalApiException;
 import com.f12.moitz.common.error.exception.RetryableApiException;
+import com.f12.moitz.domain.RecommendCondition;
 import com.f12.moitz.infrastructure.client.gemini.GoogleGeminiClient;
 import com.f12.moitz.infrastructure.client.perplexity.PerplexityClient;
 import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
@@ -36,12 +37,13 @@ public class LocationRecommenderAdapter implements LocationRecommender {
     public RecommendedLocationsResponse recommendLocations(
             final List<String> startingPlaces,
             final List<String> candidatePlaces,
-            final List<String> requirements
+            final List<RecommendCondition> requirements
     ) {
+        final List<String> requirementStrings = RecommendCondition.getRequirements(requirements);
         final Supplier<RecommendedLocationsResponse> geminiCall = () -> geminiClient.generateResponse(
                 startingPlaces,
                 candidatePlaces,
-                requirements
+                requirementStrings
         );
 
         final Supplier<RecommendedLocationsResponse> decoratedGeminiCall = Decorators.ofSupplier(geminiCall)
@@ -49,7 +51,7 @@ public class LocationRecommenderAdapter implements LocationRecommender {
                 .withCircuitBreaker(geminiRetryableBreaker)
                 .withFallback(
                         List.of(ExternalApiException.class, CallNotPermittedException.class),
-                        throwable -> fallback(startingPlaces, requirements)
+                        throwable -> fallback(startingPlaces, requirementStrings)
                 )
                 .decorate();
 
@@ -73,11 +75,12 @@ public class LocationRecommenderAdapter implements LocationRecommender {
     public RecommendedLocationsResponse recoverRecommendedLocations(
             final List<String> startingPlaces,
             final List<String> candidatePlaces,
-            final List<String> requirements
+            final List<RecommendCondition> requirements
     ) {
+        final List<String> requirementStrings = RecommendCondition.getRequirements(requirements);
         final RecommendedLocationsResponse generatedResponse = perplexityClient.generateResponse(
                 startingPlaces,
-                String.join(",", requirements)
+                String.join(",", requirementStrings)
         );
         final RecommendedLocationsResponse deduplicatedLocations = deduplicateLocation(generatedResponse);
         return excludeStartPlaces(

--- a/backend/src/main/java/com/f12/moitz/infrastructure/adapter/PlaceRecommenderAdapter.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/adapter/PlaceRecommenderAdapter.java
@@ -7,6 +7,7 @@ import com.f12.moitz.domain.Point;
 import com.f12.moitz.domain.RecommendCondition;
 import com.f12.moitz.domain.RecommendedPlace;
 import com.f12.moitz.infrastructure.client.kakao.KakaoMapClient;
+import com.f12.moitz.infrastructure.client.kakao.dto.DocumentResponse;
 import com.f12.moitz.infrastructure.client.kakao.dto.KakaoApiResponse;
 import com.f12.moitz.infrastructure.client.kakao.dto.KakaoApiResponses;
 import com.f12.moitz.infrastructure.client.kakao.dto.SearchPlacesLimitQuantityRequest;
@@ -30,42 +31,54 @@ public class PlaceRecommenderAdapter implements PlaceRecommender {
     @Override
     public Map<Place, CategorizedRecommendedPlaces> recommendPlaces(
             final List<Place> targetPlaces,
-            final List<String> requirements
+            final List<RecommendCondition> requirements
     ) {
         final Map<Place, KakaoApiResponses> searchResults = searchPlacesWithRequirement(targetPlaces, requirements);
+        return buildCategorizedRecommendedPlaces(searchResults);
+    }
 
+    private Map<Place, CategorizedRecommendedPlaces> buildCategorizedRecommendedPlaces(
+            final Map<Place, KakaoApiResponses> searchResults
+    ) {
         return searchResults.entrySet().stream()
                 .collect(Collectors.toMap(
                         Entry::getKey,
                         entry -> new CategorizedRecommendedPlaces(
-                                entry.getValue()
-                                        .kakaoApiResponses()
-                                        .entrySet().stream()
-                                        .collect(Collectors.toMap(
-                                                Entry::getKey,
-                                                reqEntry -> reqEntry.getValue().stream()
-                                                        .flatMap(resp -> resp.documents().stream())
-                                                        .map(document -> new RecommendedPlace(
-                                                                document.placeName(),
-                                                                new Point(
-                                                                        Double.parseDouble(document.x()),
-                                                                        Double.parseDouble(document.y())
-                                                                ),
-                                                                parseCategoryName(document.categoryName()),
-                                                                calculateWalkingTime(Integer.parseInt(document.distance())),
-                                                                document.placeUrl(),
-                                                                document.imageUrl()
-                                                        ))
-                                                        .toList()
-                                        ))
+                                buildCategoryMap(entry.getValue().kakaoApiResponses())
                         )
                 ));
+    }
 
+    private Map<RecommendCondition, List<RecommendedPlace>> buildCategoryMap(
+            final Map<RecommendCondition, List<KakaoApiResponse>> categoryResponses
+    ) {
+        return categoryResponses.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Entry::getKey,
+                        entry -> entry.getValue().stream()
+                                .flatMap(resp -> resp.documents().stream())
+                                .map(this::toRecommendedPlace)
+                                .toList()
+                ));
+    }
+
+    private RecommendedPlace toRecommendedPlace(final DocumentResponse document) {
+        return new RecommendedPlace(
+                document.placeName(),
+                new Point(
+                        Double.parseDouble(document.x()),
+                        Double.parseDouble(document.y())
+                ),
+                parseCategoryName(document.categoryName()),
+                calculateWalkingTime(Integer.parseInt(document.distance())),
+                document.placeUrl(),
+                document.imageUrl()
+        );
     }
 
     private Map<Place, KakaoApiResponses> searchPlacesWithRequirement(
             final List<Place> targets,
-            final List<String> requirements
+            final List<RecommendCondition> requirements
     ) {
         return targets.stream()
                 .collect(Collectors.toMap(
@@ -73,20 +86,8 @@ public class PlaceRecommenderAdapter implements PlaceRecommender {
                         place -> {
                             Map<RecommendCondition, List<KakaoApiResponse>> responsesByCategory =
                                     requirements.stream().collect(Collectors.toMap(
-                                            RecommendCondition::fromKeyword,
-                                            requirement -> {
-                                                KakaoApiResponse response = kakaoMapClient.searchPlacesBy(
-                                                        new SearchPlacesLimitQuantityRequest(
-                                                                requirement,
-                                                                place.getName(),
-                                                                place.getPoint().getX(),
-                                                                place.getPoint().getY(),
-                                                                800,
-                                                                3
-                                                        )
-                                                );
-                                                return new ArrayList<>(List.of(response));
-                                            },
+                                            condition -> condition,
+                                            condition -> searchKeywordsForCondition(place, condition),
                                             (existing, incoming) -> {
                                                 existing.addAll(incoming);
                                                 return existing;
@@ -95,6 +96,34 @@ public class PlaceRecommenderAdapter implements PlaceRecommender {
                             return new KakaoApiResponses(responsesByCategory);
                         }
                 ));
+    }
+
+    private List<KakaoApiResponse> searchKeywordsForCondition(
+            final Place place,
+            final RecommendCondition condition
+    ) {
+        List<KakaoApiResponse> allResponses = new ArrayList<>();
+        for (String keyword : condition.getKeywords()) {
+            try {
+                KakaoApiResponse response = kakaoMapClient.searchPlacesBy(
+                        new SearchPlacesLimitQuantityRequest(
+                                keyword,
+                                place.getName(),
+                                place.getPoint().getX(),
+                                place.getPoint().getY(),
+                                800,
+                                3
+                        )
+                );
+                allResponses.add(response);
+            } catch (Exception e) {
+                log.warn(
+                        "Failed to search places for keyword: {} at place: {}",
+                        keyword, place.getName(), e
+                );
+            }
+        }
+        return allResponses;
     }
 
     private int calculateWalkingTime(final int distance) {

--- a/backend/src/main/java/com/f12/moitz/infrastructure/adapter/PlaceRecommenderAsyncAdapter.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/adapter/PlaceRecommenderAsyncAdapter.java
@@ -1,6 +1,8 @@
 package com.f12.moitz.infrastructure.adapter;
 
 import com.f12.moitz.application.port.AsyncPlaceRecommender;
+import com.f12.moitz.common.error.exception.ExternalApiErrorCode;
+import com.f12.moitz.common.error.exception.ExternalApiException;
 import com.f12.moitz.domain.CategorizedRecommendedPlaces;
 import com.f12.moitz.domain.Place;
 import com.f12.moitz.domain.Point;
@@ -10,7 +12,6 @@ import com.f12.moitz.infrastructure.client.kakao.KakaoMapAsyncClient;
 import com.f12.moitz.infrastructure.client.kakao.dto.DocumentResponse;
 import com.f12.moitz.infrastructure.client.kakao.dto.KakaoApiResponse;
 import com.f12.moitz.infrastructure.client.kakao.dto.SearchPlacesLimitQuantityRequest;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -114,11 +115,12 @@ public class PlaceRecommenderAsyncAdapter implements AsyncPlaceRecommender {
                                 3
                         )
                 )
-                .doOnError(e -> log.warn(
-                        "Failed to search places for keyword: {} at place: {}",
-                        keyword, place.getName(), e
+                .retry(2)
+                .onErrorMap(e -> new ExternalApiException(
+                        ExternalApiErrorCode.INVALID_KAKAO_MAP_API_RESPONSE,
+                        "조건 '" + condition.getTitle() + "'의 키워드 '" + keyword +
+                        "'에 대한 검색이 실패했습니다. / " + e.getMessage()
                 ))
-                .onErrorResume(e -> Mono.empty())
                 )
                 .collectList()
                 .map(responses -> Map.entry(condition, responses));

--- a/backend/src/main/java/com/f12/moitz/infrastructure/adapter/PlaceRecommenderAsyncAdapter.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/adapter/PlaceRecommenderAsyncAdapter.java
@@ -1,0 +1,136 @@
+package com.f12.moitz.infrastructure.adapter;
+
+import com.f12.moitz.application.port.AsyncPlaceRecommender;
+import com.f12.moitz.domain.CategorizedRecommendedPlaces;
+import com.f12.moitz.domain.Place;
+import com.f12.moitz.domain.Point;
+import com.f12.moitz.domain.RecommendCondition;
+import com.f12.moitz.domain.RecommendedPlace;
+import com.f12.moitz.infrastructure.client.kakao.KakaoMapAsyncClient;
+import com.f12.moitz.infrastructure.client.kakao.dto.KakaoApiResponse;
+import com.f12.moitz.infrastructure.client.kakao.dto.SearchPlacesLimitQuantityRequest;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PlaceRecommenderAsyncAdapter implements AsyncPlaceRecommender {
+
+    private final KakaoMapAsyncClient kakaoMapAsyncClient;
+
+    public Mono<Map<Place, CategorizedRecommendedPlaces>> recommendPlacesAsync(
+            final List<Place> targetPlaces,
+            final List<String> requirements
+    ) {
+        return searchPlacesWithRequirementAsync(targetPlaces, requirements)
+                .map(this::buildCategorizedRecommendedPlaces);
+    }
+
+    private Map<Place, CategorizedRecommendedPlaces> buildCategorizedRecommendedPlaces(
+            final Map<Place, Map<RecommendCondition, List<KakaoApiResponse>>> searchResults
+    ) {
+        return searchResults.entrySet().stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        Entry::getKey,
+                        entry -> new CategorizedRecommendedPlaces(
+                                buildCategoryMap(entry.getValue())
+                        )
+                ));
+    }
+
+    private Map<RecommendCondition, List<RecommendedPlace>> buildCategoryMap(
+            final Map<RecommendCondition, List<KakaoApiResponse>> categoryResponses
+    ) {
+        return categoryResponses.entrySet().stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        Entry::getKey,
+                        entry -> entry.getValue().stream()
+                                .flatMap(resp -> resp.documents().stream())
+                                .map(this::toRecommendedPlace)
+                                .toList()
+                ));
+    }
+
+    private RecommendedPlace toRecommendedPlace(
+            final com.f12.moitz.infrastructure.client.kakao.dto.DocumentResponse document
+    ) {
+        return new RecommendedPlace(
+                document.placeName(),
+                new Point(
+                        Double.parseDouble(document.x()),
+                        Double.parseDouble(document.y())
+                ),
+                parseCategoryName(document.categoryName()),
+                calculateWalkingTime(Integer.parseInt(document.distance())),
+                document.placeUrl(),
+                document.imageUrl()
+        );
+    }
+
+    private Mono<Map<Place, Map<RecommendCondition, List<KakaoApiResponse>>>> searchPlacesWithRequirementAsync(
+            final List<Place> targetPlaces,
+            final List<String> requirements
+    ) {
+        return Flux.fromIterable(targetPlaces)
+                .flatMap(place -> searchRequirementsForPlaceAsync(place, requirements)
+                        .map(requirementMap -> Map.entry(place, requirementMap))
+                )
+                .collectMap(Map.Entry::getKey, Map.Entry::getValue);
+    }
+
+    private Mono<Map<RecommendCondition, List<KakaoApiResponse>>> searchRequirementsForPlaceAsync(
+            final Place place,
+            final List<String> requirements
+    ) {
+        return Flux.fromIterable(requirements)
+                .flatMap(requirement -> kakaoMapAsyncClient.searchPlacesByAsync(
+                        new SearchPlacesLimitQuantityRequest(
+                                requirement,
+                                place.getName(),
+                                place.getPoint().getX(),
+                                place.getPoint().getY(),
+                                800,
+                                3
+                        )
+                )
+                        .map(response -> Map.entry(
+                                RecommendCondition.fromKeyword(requirement),
+                                new ArrayList<>(List.of(response))
+                        ))
+                        .doOnError(e -> log.warn(
+                                "Failed to search places for requirement: {} at place: {}",
+                                requirement, place.getName(), e
+                        ))
+                        .onErrorResume(e -> {
+                            log.debug("Skipping requirement {} due to error", requirement);
+                            return Mono.empty();
+                        })
+                )
+                .collectMap(Map.Entry::getKey, Map.Entry::getValue, java.util.HashMap::new);
+    }
+
+    private int calculateWalkingTime(final int distance) {
+        return Math.toIntExact(Math.round((double) distance / 100 * 1.5));
+    }
+
+    private String parseCategoryName(final String categoryName) {
+        final String regex = ">";
+        if (!categoryName.contains(regex)) {
+            return categoryName;
+        }
+        final List<String> tokens = Arrays.stream(categoryName.split(regex))
+                .map(String::trim)
+                .toList();
+        return tokens.getLast();
+    }
+
+}

--- a/backend/src/main/java/com/f12/moitz/infrastructure/adapter/PlaceRecommenderAsyncAdapter.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/adapter/PlaceRecommenderAsyncAdapter.java
@@ -7,13 +7,16 @@ import com.f12.moitz.domain.Point;
 import com.f12.moitz.domain.RecommendCondition;
 import com.f12.moitz.domain.RecommendedPlace;
 import com.f12.moitz.infrastructure.client.kakao.KakaoMapAsyncClient;
+import com.f12.moitz.infrastructure.client.kakao.dto.DocumentResponse;
 import com.f12.moitz.infrastructure.client.kakao.dto.KakaoApiResponse;
 import com.f12.moitz.infrastructure.client.kakao.dto.SearchPlacesLimitQuantityRequest;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -29,7 +32,7 @@ public class PlaceRecommenderAsyncAdapter implements AsyncPlaceRecommender {
 
     public Mono<Map<Place, CategorizedRecommendedPlaces>> recommendPlacesAsync(
             final List<Place> targetPlaces,
-            final List<String> requirements
+            final List<RecommendCondition> requirements
     ) {
         return searchPlacesWithRequirementAsync(targetPlaces, requirements)
                 .map(this::buildCategorizedRecommendedPlaces);
@@ -39,7 +42,7 @@ public class PlaceRecommenderAsyncAdapter implements AsyncPlaceRecommender {
             final Map<Place, Map<RecommendCondition, List<KakaoApiResponse>>> searchResults
     ) {
         return searchResults.entrySet().stream()
-                .collect(java.util.stream.Collectors.toMap(
+                .collect(Collectors.toMap(
                         Entry::getKey,
                         entry -> new CategorizedRecommendedPlaces(
                                 buildCategoryMap(entry.getValue())
@@ -51,7 +54,7 @@ public class PlaceRecommenderAsyncAdapter implements AsyncPlaceRecommender {
             final Map<RecommendCondition, List<KakaoApiResponse>> categoryResponses
     ) {
         return categoryResponses.entrySet().stream()
-                .collect(java.util.stream.Collectors.toMap(
+                .collect(Collectors.toMap(
                         Entry::getKey,
                         entry -> entry.getValue().stream()
                                 .flatMap(resp -> resp.documents().stream())
@@ -61,7 +64,7 @@ public class PlaceRecommenderAsyncAdapter implements AsyncPlaceRecommender {
     }
 
     private RecommendedPlace toRecommendedPlace(
-            final com.f12.moitz.infrastructure.client.kakao.dto.DocumentResponse document
+            final DocumentResponse document
     ) {
         return new RecommendedPlace(
                 document.placeName(),
@@ -78,7 +81,7 @@ public class PlaceRecommenderAsyncAdapter implements AsyncPlaceRecommender {
 
     private Mono<Map<Place, Map<RecommendCondition, List<KakaoApiResponse>>>> searchPlacesWithRequirementAsync(
             final List<Place> targetPlaces,
-            final List<String> requirements
+            final List<RecommendCondition> requirements
     ) {
         return Flux.fromIterable(targetPlaces)
                 .flatMap(place -> searchRequirementsForPlaceAsync(place, requirements)
@@ -89,12 +92,21 @@ public class PlaceRecommenderAsyncAdapter implements AsyncPlaceRecommender {
 
     private Mono<Map<RecommendCondition, List<KakaoApiResponse>>> searchRequirementsForPlaceAsync(
             final Place place,
-            final List<String> requirements
+            final List<RecommendCondition> requirements
     ) {
         return Flux.fromIterable(requirements)
-                .flatMap(requirement -> kakaoMapAsyncClient.searchPlacesByAsync(
+                .flatMap(condition -> searchKeywordsForConditionAsync(condition, place))
+                .collectMap(Map.Entry::getKey, Map.Entry::getValue, HashMap::new);
+    }
+
+    private Mono<Map.Entry<RecommendCondition, List<KakaoApiResponse>>> searchKeywordsForConditionAsync(
+            final RecommendCondition condition,
+            final Place place
+    ) {
+        return Flux.fromIterable(condition.getKeywords())
+                .flatMap(keyword -> kakaoMapAsyncClient.searchPlacesByAsync(
                         new SearchPlacesLimitQuantityRequest(
-                                requirement,
+                                keyword,
                                 place.getName(),
                                 place.getPoint().getX(),
                                 place.getPoint().getY(),
@@ -102,20 +114,14 @@ public class PlaceRecommenderAsyncAdapter implements AsyncPlaceRecommender {
                                 3
                         )
                 )
-                        .map(response -> Map.entry(
-                                RecommendCondition.fromKeyword(requirement),
-                                new ArrayList<>(List.of(response))
-                        ))
-                        .doOnError(e -> log.warn(
-                                "Failed to search places for requirement: {} at place: {}",
-                                requirement, place.getName(), e
-                        ))
-                        .onErrorResume(e -> {
-                            log.debug("Skipping requirement {} due to error", requirement);
-                            return Mono.empty();
-                        })
+                .doOnError(e -> log.warn(
+                        "Failed to search places for keyword: {} at place: {}",
+                        keyword, place.getName(), e
+                ))
+                .onErrorResume(e -> Mono.empty())
                 )
-                .collectMap(Map.Entry::getKey, Map.Entry::getValue, java.util.HashMap::new);
+                .collectList()
+                .map(responses -> Map.entry(condition, responses));
     }
 
     private int calculateWalkingTime(final int distance) {

--- a/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapAsyncClient.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapAsyncClient.java
@@ -1,0 +1,225 @@
+package com.f12.moitz.infrastructure.client.kakao;
+
+import com.f12.moitz.common.error.exception.ExternalApiErrorCode;
+import com.f12.moitz.common.error.exception.ExternalApiException;
+import com.f12.moitz.domain.Point;
+import com.f12.moitz.infrastructure.client.kakao.dto.DocumentResponse;
+import com.f12.moitz.infrastructure.client.kakao.dto.KakaoApiResponse;
+import com.f12.moitz.infrastructure.client.kakao.dto.KakaoImageApiResponse;
+import com.f12.moitz.infrastructure.client.kakao.dto.KakaoMapErrorResponse;
+import com.f12.moitz.infrastructure.client.kakao.dto.SearchImageRequest;
+import com.f12.moitz.infrastructure.client.kakao.dto.SearchPlacesLimitQuantityRequest;
+import com.f12.moitz.infrastructure.client.kakao.dto.SearchPlacesRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class KakaoMapAsyncClient {
+
+    private static final String SEARCH_PLACE_URL = "/local/search/keyword.json?query=%s&x=%s&y=%s&radius=%d";
+    private static final String SEARCH_PLACE_WITH_SIZE_URL = "/local/search/keyword.json?query=%s&x=%s&y=%s&radius=%d&size=%d";
+    private static final String SEARCH_POINT_URL = "/local/search/keyword.json?query=%s";
+    private static final String SEARCH_IMAGE_URL = "/search/image?query=%s&page=%d&size=%d";
+    private static final List<String> ERROR_CODE_CAN_RETRY = List.of("-1", "-7", "-603");
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+    private final WebClient kakaoWebClient;
+    private final ObjectMapper objectMapper;
+
+    @Value("${kakao.api.key}")
+    private String kakaoApiKey;
+
+    public Mono<Point> searchPointByAsync(final String placeName) {
+        final String url = String.format(SEARCH_POINT_URL, placeName);
+        return getDataAsync(url)
+                .map(response -> new Point(response.findStationX(), response.findStationY()));
+    }
+
+    public Mono<KakaoApiResponse> searchPlacesByAsync(final SearchPlacesRequest request) {
+        return searchPlacesByAsync(
+                request.query(),
+                String.valueOf(request.longitude()),
+                String.valueOf(request.latitude()),
+                request.radius()
+        );
+    }
+
+    public Mono<KakaoApiResponse> searchPlacesByAsync(final SearchPlacesLimitQuantityRequest request) {
+        return searchPlacesByAsync(
+                request.query(),
+                request.name(),
+                String.valueOf(request.longitude()),
+                String.valueOf(request.latitude()),
+                request.radius(),
+                request.size()
+        );
+    }
+
+    private Mono<KakaoApiResponse> searchPlacesByAsync(
+            final String keyword,
+            final String longitude,
+            final String latitude,
+            final int radius
+    ) {
+        final String url = String.format(
+                SEARCH_PLACE_URL,
+                keyword,
+                longitude,
+                latitude,
+                radius
+        );
+        return getDataAsync(url);
+    }
+
+    private Mono<KakaoApiResponse> searchPlacesByAsync(
+            final String keyword,
+            final String stationName,
+            final String longitude,
+            final String latitude,
+            final int radius,
+            final int size
+    ) {
+        final String url = String.format(
+                SEARCH_PLACE_WITH_SIZE_URL,
+                keyword,
+                longitude,
+                latitude,
+                radius,
+                size
+        );
+        return getDataAsync(url)
+                .flatMap(response -> enrichWithImagesAsync(response, stationName));
+    }
+
+    private Mono<KakaoApiResponse> getDataAsync(final String url) {
+        return kakaoWebClient.get()
+                .uri(url)
+                .header("Authorization", "KakaoAK " + kakaoApiKey)
+                .retrieve()
+                .bodyToMono(KakaoApiResponse.class)
+                .timeout(REQUEST_TIMEOUT)
+                .onErrorMap(this::mapException);
+    }
+
+    public Mono<KakaoImageApiResponse> searchImagesByAsync(final SearchImageRequest request) {
+        final String url = String.format(
+                SEARCH_IMAGE_URL,
+                request.getQuery(),
+                request.getPage(),
+                request.getSize()
+        );
+        return getImageDataAsync(url);
+    }
+
+    private Mono<KakaoImageApiResponse> getImageDataAsync(final String url) {
+        return kakaoWebClient.get()
+                .uri(url)
+                .header("Authorization", "KakaoAK " + kakaoApiKey)
+                .retrieve()
+                .bodyToMono(KakaoImageApiResponse.class)
+                .timeout(REQUEST_TIMEOUT)
+                .onErrorMap(this::mapException);
+    }
+
+    private Mono<KakaoApiResponse> enrichWithImagesAsync(
+            final KakaoApiResponse response,
+            final String stationName
+    ) {
+        final List<Mono<DocumentResponse>> imageEnrichmentMonos = response.documents().stream()
+                .map(document -> addImageUrlToDocumentAsync(document, stationName))
+                .collect(Collectors.toList());
+
+        if (imageEnrichmentMonos.isEmpty()) {
+            return Mono.just(response);
+        }
+
+        return Mono.zip(imageEnrichmentMonos, arrays ->
+                        response.withImageUrls(
+                                java.util.Arrays.stream(arrays)
+                                        .map(obj -> (DocumentResponse) obj)
+                                        .collect(Collectors.toList())
+                        )
+                )
+                .onErrorResume(e -> {
+                    log.warn("Failed to enrich images for station: {}", stationName, e);
+                    return Mono.just(response);
+                });
+    }
+
+    private Mono<DocumentResponse> addImageUrlToDocumentAsync(
+            final DocumentResponse document,
+            final String stationName
+    ) {
+        final SearchImageRequest imageRequest = new SearchImageRequest(
+                stationName,
+                document.placeName(),
+                1,
+                1
+        );
+
+        return searchImagesByAsync(imageRequest)
+                .mapNotNull(imageResponse -> {
+                    if (imageResponse.documents() != null && !imageResponse.documents().isEmpty()) {
+                        final String imageUrl = imageResponse.documents().get(0).imageUrl();
+                        return document.withImageUrl(imageUrl);
+                    }
+                    log.debug("No image found for place: {}", document.placeName());
+                    return document.withImageUrl(null);
+                })
+                .onErrorResume(e -> {
+                    log.debug("Failed to fetch image for place: {}", document.placeName(), e);
+                    return Mono.just(document.withImageUrl(null));
+                });
+    }
+
+    private Throwable mapException(final Throwable throwable) {
+        if (throwable instanceof WebClientResponseException wcre) {
+            return mapWebClientException(wcre);
+        }
+
+        if (throwable instanceof java.util.concurrent.TimeoutException) {
+            log.error("Kakao API request timeout");
+            return new ExternalApiException(ExternalApiErrorCode.TEMPORARILY_INVALID_KAKAO_MAP_API_RESPONSE);
+        }
+
+        log.error("Kakao API request failed", throwable);
+        return new ExternalApiException(ExternalApiErrorCode.INVALID_KAKAO_MAP_API_RESPONSE);
+    }
+
+    private ExternalApiException mapWebClientException(final WebClientResponseException wcre) {
+        try {
+            final byte[] body = wcre.getResponseBodyAsString().getBytes();
+            final KakaoMapErrorResponse error = objectMapper.readValue(body, KakaoMapErrorResponse.class);
+            log.error("Kakao API error - code: {}, message: {}", error.code(), error.msg());
+
+            if (ERROR_CODE_CAN_RETRY.contains(error.code())) {
+                return new ExternalApiException(
+                        ExternalApiErrorCode.TEMPORARILY_INVALID_KAKAO_MAP_API_RESPONSE
+                );
+            }
+
+            if ("-10".equals(error.code())) {
+                return new ExternalApiException(
+                        ExternalApiErrorCode.EXCEEDED_KAKAO_MAP_API_TOKEN_QUOTA
+                );
+            }
+
+            return new ExternalApiException(ExternalApiErrorCode.INVALID_KAKAO_MAP_API_RESPONSE);
+        } catch (Exception e) {
+            log.error("Failed to parse Kakao API error response", e);
+            return new ExternalApiException(ExternalApiErrorCode.INVALID_KAKAO_MAP_API_RESPONSE);
+        }
+    }
+
+}

--- a/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapAsyncClient.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapAsyncClient.java
@@ -27,12 +27,7 @@ import reactor.core.publisher.Mono;
 @Component
 public class KakaoMapAsyncClient {
 
-    private static final String SEARCH_PLACE_URL = "/local/search/keyword.json?query=%s&x=%s&y=%s&radius=%d";
-    private static final String SEARCH_PLACE_WITH_SIZE_URL = "/local/search/keyword.json?query=%s&x=%s&y=%s&radius=%d&size=%d";
-    private static final String SEARCH_POINT_URL = "/local/search/keyword.json?query=%s";
-    private static final String SEARCH_IMAGE_URL = "/search/image?query=%s&page=%d&size=%d";
-    private static final List<String> ERROR_CODE_CAN_RETRY = List.of("-1", "-7", "-603");
-    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(KakaoMapConstants.REQUEST_TIMEOUT_SECONDS);
 
     private final WebClient kakaoWebClient;
     private final ObjectMapper objectMapper;
@@ -41,7 +36,7 @@ public class KakaoMapAsyncClient {
     private String kakaoApiKey;
 
     public Mono<Point> searchPointByAsync(final String placeName) {
-        final String url = String.format(SEARCH_POINT_URL, placeName);
+        final String url = String.format(KakaoMapConstants.SEARCH_POINT_URL, placeName);
         return getDataAsync(url)
                 .map(response -> new Point(response.findStationX(), response.findStationY()));
     }
@@ -73,7 +68,7 @@ public class KakaoMapAsyncClient {
             final int radius
     ) {
         final String url = String.format(
-                SEARCH_PLACE_URL,
+                KakaoMapConstants.SEARCH_PLACE_URL,
                 keyword,
                 longitude,
                 latitude,
@@ -91,7 +86,7 @@ public class KakaoMapAsyncClient {
             final int size
     ) {
         final String url = String.format(
-                SEARCH_PLACE_WITH_SIZE_URL,
+                KakaoMapConstants.SEARCH_PLACE_WITH_SIZE_URL,
                 keyword,
                 longitude,
                 latitude,
@@ -114,7 +109,7 @@ public class KakaoMapAsyncClient {
 
     public Mono<KakaoImageApiResponse> searchImagesByAsync(final SearchImageRequest request) {
         final String url = String.format(
-                SEARCH_IMAGE_URL,
+                KakaoMapConstants.SEARCH_IMAGE_URL,
                 request.getQuery(),
                 request.getPage(),
                 request.getSize()
@@ -203,13 +198,13 @@ public class KakaoMapAsyncClient {
             final KakaoMapErrorResponse error = objectMapper.readValue(body, KakaoMapErrorResponse.class);
             log.error("Kakao API error - code: {}, message: {}", error.code(), error.msg());
 
-            if (ERROR_CODE_CAN_RETRY.contains(error.code())) {
+            if (KakaoMapConstants.ERROR_CODE_CAN_RETRY.contains(error.code())) {
                 return new ExternalApiException(
                         ExternalApiErrorCode.TEMPORARILY_INVALID_KAKAO_MAP_API_RESPONSE
                 );
             }
 
-            if ("-10".equals(error.code())) {
+            if (KakaoMapConstants.ERROR_CODE_QUOTA_EXCEEDED.equals(error.code())) {
                 return new ExternalApiException(
                         ExternalApiErrorCode.EXCEEDED_KAKAO_MAP_API_TOKEN_QUOTA
                 );

--- a/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapClient.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapClient.java
@@ -26,12 +26,6 @@ import org.springframework.web.client.RestClient;
 @Component
 public class KakaoMapClient {
 
-    private static final String SEARCH_PLACE_URL = "/local/search/keyword.json?query=%s&x=%s&y=%s&radius=%d";
-    private static final String SEARCH_PLACE_WITH_SIZE_URL = "/local/search/keyword.json?query=%s&x=%s&y=%s&radius=%d&size=%d";
-    private static final String SEARCH_POINT_URL = "/local/search/keyword.json?query=%s";
-    private static final String SEARCH_IMAGE_URL = "/search/image?query=%s&page=%d&size=%d";
-    private static final List<String> ERROR_CODE_CAN_RETRY = List.of("-1", "-7", "-603");
-
     private final RestClient kakaoRestClient;
     private final ObjectMapper objectMapper;
 
@@ -39,7 +33,7 @@ public class KakaoMapClient {
     private String kakaoApiKey;
 
     public Point searchPointBy(final String placeName) {
-        final String url = String.format(SEARCH_POINT_URL, placeName);
+        final String url = String.format(KakaoMapConstants.SEARCH_POINT_URL, placeName);
         final KakaoApiResponse response = getData(url);
         return new Point(response.findStationX(), response.findStationY());
     }
@@ -71,7 +65,7 @@ public class KakaoMapClient {
             final int radius
     ) {
         final String url = String.format(
-                SEARCH_PLACE_URL,
+                KakaoMapConstants.SEARCH_PLACE_URL,
                 keyword,
                 longitude,
                 latitude,
@@ -89,7 +83,7 @@ public class KakaoMapClient {
             final int size
     ) {
         final String url = String.format(
-                SEARCH_PLACE_WITH_SIZE_URL,
+                KakaoMapConstants.SEARCH_PLACE_WITH_SIZE_URL,
                 keyword,
                 longitude,
                 latitude,
@@ -114,7 +108,7 @@ public class KakaoMapClient {
 
     public KakaoImageApiResponse searchImagesBy(final SearchImageRequest request) {
         final String url = String.format(
-                SEARCH_IMAGE_URL,
+                KakaoMapConstants.SEARCH_IMAGE_URL,
                 request.getQuery(),
                 request.getPage(),
                 request.getSize()
@@ -164,10 +158,10 @@ public class KakaoMapClient {
             final KakaoMapErrorResponse error = objectMapper.readValue(body,
                     KakaoMapErrorResponse.class);
             log.error(error.msg());
-            if (ERROR_CODE_CAN_RETRY.contains(error.code())) {
+            if (KakaoMapConstants.ERROR_CODE_CAN_RETRY.contains(error.code())) {
                 throw new ExternalApiException(ExternalApiErrorCode.TEMPORARILY_INVALID_KAKAO_MAP_API_RESPONSE);
             }
-            if ("-10".equals(error.code())) {
+            if (KakaoMapConstants.ERROR_CODE_QUOTA_EXCEEDED.equals(error.code())) {
                 throw new ExternalApiException(ExternalApiErrorCode.EXCEEDED_KAKAO_MAP_API_TOKEN_QUOTA);
             }
             throw new ExternalApiException(ExternalApiErrorCode.INVALID_KAKAO_MAP_API_RESPONSE);

--- a/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapClient.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapClient.java
@@ -100,16 +100,6 @@ public class KakaoMapClient {
         return enrichWithImages(response, stationName);
     }
 
-    public KakaoImageApiResponse searchImagesBy(final SearchImageRequest request) {
-        final String url = String.format(
-                SEARCH_IMAGE_URL,
-                request.getQuery(),
-                request.getPage(),
-                request.getSize()
-        );
-        return getImageData(url);
-    }
-
     private KakaoApiResponse getData(final String url) {
         return kakaoRestClient.get()
                 .uri(url)
@@ -120,6 +110,16 @@ public class KakaoMapClient {
                         (req, res) -> handleError(res)
                 )
                 .body(KakaoApiResponse.class);
+    }
+
+    public KakaoImageApiResponse searchImagesBy(final SearchImageRequest request) {
+        final String url = String.format(
+                SEARCH_IMAGE_URL,
+                request.getQuery(),
+                request.getPage(),
+                request.getSize()
+        );
+        return getImageData(url);
     }
 
     private KakaoImageApiResponse getImageData(final String url) {

--- a/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapConstants.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapConstants.java
@@ -1,0 +1,18 @@
+package com.f12.moitz.infrastructure.client.kakao;
+
+import java.util.List;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+public class KakaoMapConstants {
+
+    public static final String SEARCH_PLACE_URL = "/local/search/keyword.json?query=%s&x=%s&y=%s&radius=%d";
+    public static final String SEARCH_PLACE_WITH_SIZE_URL = "/local/search/keyword.json?query=%s&x=%s&y=%s&radius=%d&size=%d";
+    public static final String SEARCH_POINT_URL = "/local/search/keyword.json?query=%s";
+    public static final String SEARCH_IMAGE_URL = "/search/image?query=%s&page=%d&size=%d";
+
+    public static final List<String> ERROR_CODE_CAN_RETRY = List.of("-1", "-7", "-603");
+    public static final String ERROR_CODE_QUOTA_EXCEEDED = "-10";
+
+    public static final int REQUEST_TIMEOUT_SECONDS = 5;
+}

--- a/backend/src/test/java/com/f12/moitz/application/RecommendationServiceTest.java
+++ b/backend/src/test/java/com/f12/moitz/application/RecommendationServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 
 import com.f12.moitz.application.dto.RecommendationRequest;
 import com.f12.moitz.application.dto.RecommendedLocationsResponse;
+import com.f12.moitz.application.port.AsyncPlaceRecommender;
 import com.f12.moitz.application.port.LocationRecommender;
 import com.f12.moitz.application.port.PlaceRecommender;
 import com.f12.moitz.application.port.RouteFinder;
@@ -39,6 +40,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
 
 @ExtendWith(MockitoExtension.class)
 class RecommendationServiceTest {
@@ -50,6 +52,9 @@ class RecommendationServiceTest {
 
     @Mock
     private PlaceRecommender placeRecommender;
+
+    @Mock
+    private AsyncPlaceRecommender asyncPlaceRecommender;
 
     @Mock
     private SubwayStationService subwayStationService;
@@ -68,6 +73,7 @@ class RecommendationServiceTest {
         recommendationService = new RecommendationService(
                 subwayStationService,
                 placeRecommender,
+                asyncPlaceRecommender,
                 locationRecommender,
                 routeFinder,
                 recommendationMapper,
@@ -125,7 +131,8 @@ class RecommendationServiceTest {
                         )
                 )
         );
-        given(placeRecommender.recommendPlaces(anyList(), anyList())).willReturn(mockRecommendedPlaces);
+        given(asyncPlaceRecommender.recommendPlacesAsync(anyList(), anyList()))
+                .willReturn(Mono.just(mockRecommendedPlaces));
 
         List<Route> mockRoutes = List.of(
                 new Route(List.of(new Path(gangnam, seolleung, TravelMethod.SUBWAY, 10, SubwayLine.fromTitle("2호선")))),


### PR DESCRIPTION
# #️⃣ Issue Number
#475 

## 🕹️ 작업 내용

한 줄 요약 : 카테고리 중복 선택 도입 이후 카카오 장소 검색 로직을 병렬 처리

- [x] 카카오 API RestClient -> WebClient
- [x] 비동기 병렬 요청 로직 추가

## 📋 리뷰 포인트

- 전체적으로 컨벤션 등 다시 한 번 점검 부탁드립니당

## 🔮 기타 사항
환경은 로컬로 동일하게 세팅하고, 다음과 같이 요청, 응답을 받을 시 소요 시간 차이를 측정해보았어요.
아무래도 실제 환경이 아니기 때문에 정확한 결과로 볼 순 없지만, 수치 차이를 비교하는 데에는 충분하다고 생각했어요!

### 요청 데이터
``` json
{
  "startingPlaceNames": [
    "수원역",
    "인천역"
  ],
  "requirements" : ["CAFE", "RESTAURANT", "BAR", "ENTERTAINMENT"]
}
```

### 기존 로직 요청 소요 시간
<img width="550" height="400" alt="스크린샷 2025-10-22 오후 5 49 59" src="https://github.com/user-attachments/assets/fac118c5-8210-43c1-9ee9-cad0cbbc8f77" />

### 변경 이후 요청 소요 시간
<img width="550" height="400" alt="스크린샷 2025-10-22 오후 5 48 32" src="https://github.com/user-attachments/assets/b935f3b4-4424-4401-b7f8-3dc9ee99b038" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 추천 기능의 내부 아키텍처를 비동기 처리 방식으로 개선하여 성능 및 확장성을 향상했습니다.

* **Tests**
  * 비동기 처리에 대응하도록 추천 서비스 테스트를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->