### PR TITLE
[BE] feat: 이미지 Base64 인코딩 적용

### DIFF
--- a/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapAsyncClient.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapAsyncClient.java
@@ -29,6 +29,7 @@ import reactor.core.publisher.Mono;
 public class KakaoMapAsyncClient {
 
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(KakaoMapConstants.REQUEST_TIMEOUT_SECONDS);
+    private static final Duration IMAGE_DOWNLOAD_TIMEOUT = Duration.ofSeconds(10);
 
     private final WebClient kakaoWebClient;
     private final ObjectMapper objectMapper;
@@ -190,22 +191,39 @@ public class KakaoMapAsyncClient {
             return Mono.empty();
         }
 
+        long startTime = System.currentTimeMillis();
+
         return kakaoWebClient.get()
                 .uri(imageUrl)
                 .retrieve()
-                .bodyToMono(byte[].class)
-                .timeout(REQUEST_TIMEOUT)
-                .map(imageBytes -> {
+                .toEntity(byte[].class)
+                .timeout(IMAGE_DOWNLOAD_TIMEOUT)
+                .map(response -> {
+                    long elapsed = System.currentTimeMillis() - startTime;
+                    byte[] imageBytes = response.getBody();
                     if (imageBytes == null || imageBytes.length == 0) {
+                        log.debug("Downloaded empty image in {}ms: {}", elapsed, imageUrl);
                         return null;
                     }
+                    log.debug("Image downloaded in {}ms: {}", elapsed, imageUrl);
+                    String mediaType = getMediaTypeFromResponse(response);
                     String base64 = Base64.getEncoder().encodeToString(imageBytes);
-                    return "data:image/jpeg;base64," + base64;
+                    return "data:" + mediaType + ";base64," + base64;
                 })
                 .onErrorResume(e -> {
-                    log.warn("Failed to download image from URL: {}", imageUrl, e);
+                    long elapsed = System.currentTimeMillis() - startTime;
+                    log.warn("Image download failed after {}ms: {}", elapsed, imageUrl, e);
                     return Mono.empty();
                 });
+    }
+
+    private String getMediaTypeFromResponse(
+            org.springframework.http.ResponseEntity<byte[]> response) {
+        org.springframework.http.MediaType contentType = response.getHeaders().getContentType();
+        if (contentType != null) {
+            return contentType.toString();
+        }
+        return "image/jpeg"; // 기본값
     }
 
     private Throwable mapException(final Throwable throwable) {

--- a/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapAsyncClient.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapAsyncClient.java
@@ -170,7 +170,8 @@ public class KakaoMapAsyncClient {
                     if (imageResponse.documents() != null && !imageResponse.documents().isEmpty()) {
                         final String imageUrl = imageResponse.documents().get(0).thumbnailUrl();
                         return downloadImageAsBase64Async(imageUrl)
-                                .map(base64 -> document.withImageUrl(base64))
+                                .map(document::withImageUrl)
+                                .switchIfEmpty(Mono.just(document.withImageUrl(null)))
                                 .onErrorResume(e -> {
                                     log.debug("Failed to download image as base64 for place: {}",
                                             document.placeName(), e);
@@ -198,17 +199,17 @@ public class KakaoMapAsyncClient {
                 .retrieve()
                 .toEntity(byte[].class)
                 .timeout(IMAGE_DOWNLOAD_TIMEOUT)
-                .map(response -> {
+                .flatMap(response -> {
                     long elapsed = System.currentTimeMillis() - startTime;
                     byte[] imageBytes = response.getBody();
                     if (imageBytes == null || imageBytes.length == 0) {
                         log.debug("Downloaded empty image in {}ms: {}", elapsed, imageUrl);
-                        return null;
+                        return Mono.empty();
                     }
                     log.debug("Image downloaded in {}ms: {}", elapsed, imageUrl);
                     String mediaType = getMediaTypeFromResponse(response);
                     String base64 = Base64.getEncoder().encodeToString(imageBytes);
-                    return "data:" + mediaType + ";base64," + base64;
+                    return Mono.just("data:" + mediaType + ";base64," + base64);
                 })
                 .onErrorResume(e -> {
                     long elapsed = System.currentTimeMillis() - startTime;
@@ -223,7 +224,7 @@ public class KakaoMapAsyncClient {
         if (contentType != null) {
             return contentType.toString();
         }
-        return "image/jpeg"; // 기본값
+        return "image/jpeg";
     }
 
     private Throwable mapException(final Throwable throwable) {

--- a/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapAsyncClient.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapAsyncClient.java
@@ -12,6 +12,7 @@ import com.f12.moitz.infrastructure.client.kakao.dto.SearchPlacesLimitQuantityRe
 import com.f12.moitz.infrastructure.client.kakao.dto.SearchPlacesRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
+import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -164,17 +165,46 @@ public class KakaoMapAsyncClient {
         );
 
         return searchImagesByAsync(imageRequest)
-                .mapNotNull(imageResponse -> {
+                .flatMap(imageResponse -> {
                     if (imageResponse.documents() != null && !imageResponse.documents().isEmpty()) {
-                        final String imageUrl = imageResponse.documents().get(0).imageUrl();
-                        return document.withImageUrl(imageUrl);
+                        final String imageUrl = imageResponse.documents().get(0).thumbnailUrl();
+                        return downloadImageAsBase64Async(imageUrl)
+                                .map(base64 -> document.withImageUrl(base64))
+                                .onErrorResume(e -> {
+                                    log.debug("Failed to download image as base64 for place: {}",
+                                            document.placeName(), e);
+                                    return Mono.just(document.withImageUrl(null));
+                                });
                     }
                     log.debug("No image found for place: {}", document.placeName());
-                    return document.withImageUrl(null);
+                    return Mono.just(document.withImageUrl(null));
                 })
                 .onErrorResume(e -> {
                     log.debug("Failed to fetch image for place: {}", document.placeName(), e);
                     return Mono.just(document.withImageUrl(null));
+                });
+    }
+
+    private Mono<String> downloadImageAsBase64Async(final String imageUrl) {
+        if (imageUrl == null || imageUrl.isEmpty()) {
+            return Mono.empty();
+        }
+
+        return kakaoWebClient.get()
+                .uri(imageUrl)
+                .retrieve()
+                .bodyToMono(byte[].class)
+                .timeout(REQUEST_TIMEOUT)
+                .map(imageBytes -> {
+                    if (imageBytes == null || imageBytes.length == 0) {
+                        return null;
+                    }
+                    String base64 = Base64.getEncoder().encodeToString(imageBytes);
+                    return "data:image/jpeg;base64," + base64;
+                })
+                .onErrorResume(e -> {
+                    log.warn("Failed to download image from URL: {}", imageUrl, e);
+                    return Mono.empty();
                 });
     }
 

--- a/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapClient.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapClient.java
@@ -178,22 +178,32 @@ public class KakaoMapClient {
                 return null;
             }
 
-            byte[] imageBytes = kakaoRestClient.get()
+            org.springframework.http.ResponseEntity<byte[]> response = kakaoRestClient.get()
                     .uri(imageUrl)
                     .retrieve()
-                    .body(byte[].class);
+                    .toEntity(byte[].class);
 
+            byte[] imageBytes = response.getBody();
             if (imageBytes == null || imageBytes.length == 0) {
                 log.warn("Downloaded image is empty for URL: {}", imageUrl);
                 return null;
             }
 
+            String mediaType = getMediaTypeFromResponse(response);
             String base64 = Base64.getEncoder().encodeToString(imageBytes);
-            return "data:image/jpeg;base64," + base64;
+            return "data:" + mediaType + ";base64," + base64;
         } catch (Exception e) {
             log.warn("Failed to download image from URL: {}", imageUrl, e);
             return null;
         }
+    }
+
+    private String getMediaTypeFromResponse(org.springframework.http.ResponseEntity<byte[]> response) {
+        org.springframework.http.MediaType contentType = response.getHeaders().getContentType();
+        if (contentType != null) {
+            return contentType.toString();
+        }
+        return "image/jpeg"; // 기본값
     }
 
 }

--- a/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapClient.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapClient.java
@@ -12,6 +12,7 @@ import com.f12.moitz.infrastructure.client.kakao.dto.SearchPlacesLimitQuantityRe
 import com.f12.moitz.infrastructure.client.kakao.dto.SearchPlacesRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -141,7 +142,7 @@ public class KakaoMapClient {
             final KakaoImageApiResponse imageResponse = searchImagesBy(imageRequest);
 
             if (imageResponse.documents() != null && !imageResponse.documents().isEmpty()) {
-                final String imageUrl = imageResponse.documents().get(0).imageUrl();
+                final String imageUrl = imageResponse.documents().get(0).thumbnailUrl();
                 return document.withImageUrl(imageUrl);
             }
             log.info("No image found for place: {}", document.placeName());
@@ -167,6 +168,31 @@ public class KakaoMapClient {
             throw new ExternalApiException(ExternalApiErrorCode.INVALID_KAKAO_MAP_API_RESPONSE);
         } catch (IOException e) {
             throw new ExternalApiException(ExternalApiErrorCode.INVALID_KAKAO_MAP_API_RESPONSE);
+        }
+    }
+
+    public String downloadImageAsBase64(final String imageUrl) {
+        try {
+            if (imageUrl == null || imageUrl.isEmpty()) {
+                log.warn("Image URL is null or empty");
+                return null;
+            }
+
+            byte[] imageBytes = kakaoRestClient.get()
+                    .uri(imageUrl)
+                    .retrieve()
+                    .body(byte[].class);
+
+            if (imageBytes == null || imageBytes.length == 0) {
+                log.warn("Downloaded image is empty for URL: {}", imageUrl);
+                return null;
+            }
+
+            String base64 = Base64.getEncoder().encodeToString(imageBytes);
+            return "data:image/jpeg;base64," + base64;
+        } catch (Exception e) {
+            log.warn("Failed to download image from URL: {}", imageUrl, e);
+            return null;
         }
     }
 

--- a/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapClient.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/client/kakao/KakaoMapClient.java
@@ -171,7 +171,7 @@ public class KakaoMapClient {
         }
     }
 
-    public String downloadImageAsBase64(final String imageUrl) {
+    private String downloadImageAsBase64(final String imageUrl) {
         try {
             if (imageUrl == null || imageUrl.isEmpty()) {
                 log.warn("Image URL is null or empty");


### PR DESCRIPTION
# #️⃣ Issue Number
#483 

## 🕹️ 작업 내용

한 줄 요약 : 카카오 이미지에 대한 Base64 인코딩 적용

- [ ] WebClient 비동기 처리 중 이미지 URL에 대한 인코딩 작업

## 📋 리뷰 포인트

- 오타 등 확인해주시면 감사드릴게용 :)

## 🔮 기타 사항

기존 이슈를 해결할 다음과 같은 방법들이 존재했어요.

1. 프록시 서버
구현하기 단순했고, 당장의 CORS를 처리하는데 문제는 없겠지만
이미지를 JSON에 바로 담을 수 없다보니 content-type을 바꾸어야 해서 별도 API가 추가되어요.
사진 개수만큼의 요청이 추가적으로 발생하게 되고 최악의 경우 225(= 5개의 지역 * 15개의 카테고리 * 3개의 장소)번이 발생하게 되어요.
요청이 많고, 이미지를 직접 처리하니 서버 부하가 높아지게 되겠죠.

2. 프록시 + 캐싱
프록시 서버 방법에 캐싱을 더한 방법이에요. 1번보다 동일한 장소에 대해서는 속도가 빠른 장점이 있겠지만
이미지를 캐싱하기 때문에 메모리를 많이 사용하게 되고, 서비스 특성 상 반복적인 장소가 나오지 않을 가능성이 더 높아요.

3. S3 등 저장
동일한 이미지에 대해 매번 외부에 요청하지 않아도 되기 때문에 외부 서비스의 의존성이 줄어들고, 안정적인 장점에 가장 이상적인 방법일 수 있겠지만
스토리지 비용, 다른 방법에 비해 러닝 커브가 높으며, 카카오 API 정책상 저장할 수 없기 때문에 이번 이슈에서는 배제하였어요.

4. Base64 인코딩
이미지를 인코딩하여 기존 JSON 응답의 URL 대체하는 방식이에요.
이 중 가장 구현하기 단순하고, 추가 요청이 없다는 큰 장점이 있어요.
다만 인코딩하면 기존보다도 사이즈가 증가하기 때문에 JSON 크기가 비대해지고, 브라우저 캐싱이 힘들며, 파싱이 느려요.

이 중 4번째 방법을 선택하게 되었는데요!

카카오는 이미지 URL과 함께 썸네일 URL도 함께 제공해요. 일반적으로 크기가 작기 때문에 용량이 작아요. (약 5KB 정도) 따라서 Base64를 인코딩 해도, 최악의 경우를 가정해도 프록시 서버를 구성하는 방식보다 요청 수 대비 시간을 고려했을 때 더 낫다고 판단했어요.

대략적인 계산을 해보면 다음과 같아요.
- 4번, Base64 : 10KB * 225 = 약 2MB, gzip 압축 포함 약 500KB라고 가정하면, 약 10 Mbps(1.25MB/s)의 인터넷 속도 기준으로 500 ÷ 1.25 = 약 400ms 지연
- 1번, 프록시 서버 :  각 요청당 약 50ms로 가정해도 50 * 200 = 약 10초 지연 (당연히 더 나을 수도, 나쁠 수도 있어요.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 이미지 다운로드 실패 시 더욱 안정적인 오류 처리 추가
  * 이미지 로딩 중 서비스 중단 문제 개선

* **Refactor**
  * 이미지 처리 방식 최적화로 안정성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->