### PR TITLE
[FE] fix: CI/CD workflows에서 다운로드 아티팩트 경로를 frontend/dist에서 dist로 변경

### DIFF
--- a/.github/workflows/fe-ci.yml
+++ b/.github/workflows/fe-ci.yml
@@ -62,5 +62,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dist
-          path: frontend/dist
+          path: dist
           retention-days: 1


### PR DESCRIPTION
# #️⃣ Issue Number

## 🕹️ 작업 내용

한 줄 요약 :

- [ ]
- [ ]

## 📋 리뷰 포인트

-
-

## 🔮 기타 사항

-
-
