### PR TITLE
[BE] chore: Redis properties 값을 프로필에 따라 분리

### DIFF
--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -1,3 +1,4 @@
 spring.data.mongodb.host=10.0.0.68
+spring.redis.host=127.0.0.1
 monitoring.namespace=Moitz2025Dev
 logging.file.path=/home/ubuntu/app-logs

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -1,3 +1,4 @@
 spring.data.mongodb.host=10.0.100.220
+spring.redis.host=redis
 monitoring.namespace=Moitz2025Prod
 logging.file.path=/var/snap/amazon-ssm-agent/11798/app-logs

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -3,8 +3,7 @@ spring.application.name=moitz
 spring.profiles.group.dev=dev,devclient,db
 spring.profiles.group.prod=prod,client,db
 
-spring.redis.host= redis
-spring.redis.port= 6379
+spring.redis.port=6379
 spring.redis.timeout=60000ms
 
 dev.logging.file.debug.path=/home/ubuntu/app-logs/debug


### PR DESCRIPTION
## 🕹️ 작업 내용

한 줄 요약 : application.properties 내 Redis 관련 설정 값을 개발, 운영 환경에 따라 분리했습니다.

## 🔮 기타 사항

- 개발 환경에서는 도커를 사용하지 않아, `spring.redis.host` 값에 호스트 IP를 직접적으로 넣어줘야 해서 해당 사항 반영했습니다.
