### PR TITLE
[FE] fix: FE CD 파이프라인 러너 및 AWS 인증 방식을 OIDC 기반으로 변경

### DIFF
--- a/.github/workflows/fe-ci.yml
+++ b/.github/workflows/fe-ci.yml
@@ -70,12 +70,18 @@ jobs:
 
       - name: 빌드 실행 (fe-prod)
         id: build-prod
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/fe-prod') || (github.event_name == 'pull_request' && github.base_ref == 'fe-prod') || (github.event_name == 'workflow_dispatch')
+        if: |
+          (github.event_name == 'push' && github.ref == 'refs/heads/fe-prod') || 
+          (github.event_name == 'pull_request' && github.base_ref == 'fe-prod') || 
+          github.event_name == 'workflow_dispatch'
         run: npm run build:prod
 
       - name: 빌드 실행 (fe-dev)
         id: build-dev
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/fe-dev') || (github.event_name == 'pull_request' && github.base_ref == 'fe-dev') || (github.event_name == 'workflow_dispatch')
+        if: |
+          (github.event_name == 'push' && github.ref == 'refs/heads/fe-dev') || 
+          (github.event_name == 'pull_request' && github.base_ref == 'fe-dev') || 
+          github.event_name == 'workflow_dispatch'
         run: npm run build:dev
 
       - name: 빌드 결과물 업로드

--- a/.github/workflows/fe-ci.yml
+++ b/.github/workflows/fe-ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: npm run build:prod
 
       - name: 빌드 실행 (fe-dev)
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/fe-dev') || (github.event_name == 'pull_request' && github.base_ref == 'fe-dev') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/fe-dev')
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/fe-dev') || (github.event_name == 'pull_request' && github.base_ref == 'fe-dev') || (github.event_name == 'workflow_dispatch')
         run: npm run build:dev
 
       - name: 빌드 결과물 업로드

--- a/.github/workflows/fe-ci.yml
+++ b/.github/workflows/fe-ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: npx jest --verbose --coverage
 
       - name: 빌드 실행 (fe-prod)
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/fe-prod') || (github.event_name == 'pull_request' && github.base_ref == 'fe-prod') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/fe-prod')
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/fe-prod') || (github.event_name == 'pull_request' && github.base_ref == 'fe-prod') || (github.event_name == 'workflow_dispatch')
         run: npm run build:prod
 
       - name: 빌드 실행 (fe-dev)

--- a/.github/workflows/fe-ci.yml
+++ b/.github/workflows/fe-ci.yml
@@ -69,14 +69,17 @@ jobs:
         run: npx jest --verbose --coverage
 
       - name: 빌드 실행 (fe-prod)
+        id: build-prod
         if: (github.event_name == 'push' && github.ref == 'refs/heads/fe-prod') || (github.event_name == 'pull_request' && github.base_ref == 'fe-prod') || (github.event_name == 'workflow_dispatch')
         run: npm run build:prod
 
       - name: 빌드 실행 (fe-dev)
+        id: build-dev
         if: (github.event_name == 'push' && github.ref == 'refs/heads/fe-dev') || (github.event_name == 'pull_request' && github.base_ref == 'fe-dev') || (github.event_name == 'workflow_dispatch')
         run: npm run build:dev
 
       - name: 빌드 결과물 업로드
+        if: steps.build-prod.outcome == 'success' || steps.build-dev.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: build-result

--- a/.github/workflows/fe-dev-cd.yml
+++ b/.github/workflows/fe-dev-cd.yml
@@ -28,7 +28,7 @@ jobs:
       github.actor == 'eunsoA' || 
       github.actor == 'kaori-killer'
 
-    runs-on: [self-hosted, prod]
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/fe-dev-cd.yml
+++ b/.github/workflows/fe-dev-cd.yml
@@ -42,6 +42,12 @@ jobs:
       - name: 코드 가져오기
         uses: actions/checkout@v4
 
+      - name: AWS 자격 증명 설정 (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/FEGitHubActionsDeploymentRole
+          aws-region: ap-northeast-2
+
       - name: CI 빌드 결과물 다운로드
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/fe-dev-cd.yml
+++ b/.github/workflows/fe-dev-cd.yml
@@ -24,7 +24,6 @@ jobs:
       contents: read
     if: >
       (github.event_name == 'push' && needs.ci.result == 'success') ||
-      (github.event.pull_request.merged == true && needs.ci.result == 'success') ||
       github.actor == 'eunsoA' || 
       github.actor == 'kaori-killer'
 

--- a/.github/workflows/fe-dev-cd.yml
+++ b/.github/workflows/fe-dev-cd.yml
@@ -6,6 +6,10 @@ on:
     paths: ['frontend/**']
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   AWS_REGION: ap-northeast-2
   S3_BUCKET: moitz-service
@@ -19,9 +23,6 @@ jobs:
 
   cd:
     needs: ci
-    permissions:
-      id-token: write
-      contents: read
     if: >
       (github.event_name == 'push' && needs.ci.result == 'success') ||
       (github.event.pull_request.merged == true && needs.ci.result == 'success') ||

--- a/.github/workflows/fe-dev-cd.yml
+++ b/.github/workflows/fe-dev-cd.yml
@@ -6,10 +6,6 @@ on:
     paths: ['frontend/**']
   workflow_dispatch:
 
-permissions:
-  id-token: write
-  contents: read
-
 env:
   AWS_REGION: ap-northeast-2
   S3_BUCKET: moitz-service
@@ -23,6 +19,9 @@ jobs:
 
   cd:
     needs: ci
+    permissions:
+      id-token: write
+      contents: read
     if: >
       (github.event_name == 'push' && needs.ci.result == 'success') ||
       (github.event.pull_request.merged == true && needs.ci.result == 'success') ||

--- a/.github/workflows/fe-dev-cd.yml
+++ b/.github/workflows/fe-dev-cd.yml
@@ -19,6 +19,9 @@ jobs:
 
   cd:
     needs: ci
+    permissions:
+      id-token: write
+      contents: read
     if: >
       (github.event_name == 'push' && needs.ci.result == 'success') ||
       (github.event.pull_request.merged == true && needs.ci.result == 'success') ||

--- a/.github/workflows/fe-prod-cd.yml
+++ b/.github/workflows/fe-prod-cd.yml
@@ -24,7 +24,6 @@ jobs:
       contents: read
     if: >
       (github.event_name == 'push' && needs.ci.result == 'success') ||
-      (github.event.pull_request.merged == true && needs.ci.result == 'success') ||
       github.actor == 'eunsoA' || 
       github.actor == 'kaori-killer'
 

--- a/.github/workflows/fe-prod-cd.yml
+++ b/.github/workflows/fe-prod-cd.yml
@@ -28,7 +28,7 @@ jobs:
       github.actor == 'eunsoA' || 
       github.actor == 'kaori-killer'
 
-    runs-on: [self-hosted, prod]
+    runs-on: ubuntu-latest
 
     defaults:
       run:
@@ -41,6 +41,12 @@ jobs:
     steps:
       - name: 코드 가져오기
         uses: actions/checkout@v4
+
+      - name: AWS 자격 증명 설정 (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/FEGitHubActionsDeploymentRole
+          aws-region: ap-northeast-2
 
       - name: CI 빌드 결과물 다운로드
         uses: actions/download-artifact@v4

--- a/.github/workflows/fe-prod-cd.yml
+++ b/.github/workflows/fe-prod-cd.yml
@@ -19,6 +19,9 @@ jobs:
 
   cd:
     needs: ci
+    permissions:
+      id-token: write
+      contents: read
     if: >
       (github.event_name == 'push' && needs.ci.result == 'success') ||
       (github.event.pull_request.merged == true && needs.ci.result == 'success') ||


### PR DESCRIPTION
# #️⃣ Issue Number
#532 

## 🕹️ 작업 내용

### 변경 배경 : 
인프라 이전으로 기존 Self-hosted Runner(EC2)가 변경되며, CD에서 S3 접근 권한 부족 문제가 발생했어요.
EC2에 권한을 다시 부여하는 방식 대신, **OIDC 기반 단기 인증 방식** 으로 전환했어요. (목적 : 보안성, 단순성, 운영 비용)

### 변경 내용 요약 : 
CD 실행 환경을 GitHub Hosted Runner 로 변경했어요.
AWS 인증 방식을 EC2 Instance Role 기반 → OIDC 기반 AssumeRole 방식으로 변경했어요.

- CI Workflow 변경 내용 : 
  - [x] CI 빌드 성공시에만 CD가 실행되도록 로직 변경

- CD Workflow 변경 내용 : 
  - [x] FE CD workflow 러너를 self-hosted → ubuntu-latest 로 변경
  - [x] GitHub Actions에서 AWS에 직접 인증할 수 있도록 OIDC 기반 자동 인증 방식 도입
  - [x] CD Job에 필요한 최소 권한(permission) 설정 추가

- AWS 인프라 변경 내용 : 
  - [x] GitHub Actions용 OIDC Identity Provider 생성
  - [x] FE 배포용 IAM Role(FEGitHubActionsDeploymentRole) 생성
  - [x] Trust Policy 조건에 fe-dev / fe-prod 브랜치만 역할을 사용할 수 있도록 제한

## 📋 리뷰 포인트

- [ ] 변경된 워크플로우 스크립트 내용 중 불필요한 로직이 있는지 확인해주세요.
- [ ] IAM Role Trust Policy에서 브랜치 제한 규칙이 적절한지 확인해주세요.

## 🔮 기타 사항

- CD 파이프라인 구축 과정에서 더 자세한 내용은 아래의 문서로 정리해놨습니다.
  - [📄 CD 파이프라인 구축기 (1) - 기존 방식 정리](https://eunsoa.notion.site/Moitz-Github-Action-CD-2beb5a1edfe480cb9653f0c4831d4323?source=copy_link)
  - [📄 CD 파이프라인 구축기 (2) - OIDC 도입 및 Hosted Runner 전환](https://eunsoa.notion.site/Moitz-CD-2-OIDC-Github-Hosted-Runner-2c0b5a1edfe4803bbac0ee32984b93a3?source=copy_link) (<- 이번 PR 내용은 여기 !)

- fork repo에서는 OIDC Token이 발급되지 않아 테스트가 불가능합니다. 따라서 upstream 에 브랜치를 올려 실제 배포까지 [정상 동작 확인](https://github.com/woowacourse-teams/2025-moitz/actions/runs/19962781776)했습니다!
- AWS가 권장하는 방식(Hosted Runner + OIDC)으로 개선해서 이후 운영, 보안 측면에서도 유지보수 비용이 크게 감소할 것으로 예상돼요! 다른 더 좋은 방법이 있다면, 제안도 환영입니다!