### PR TITLE
[FE] fix: 프로덕션 빌드 시 dev용 robots.txt가 배포되는 문제 수정

### DIFF
--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -8,7 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // dev/prod에서 주입한 envVars를 받아 index.html에 templateParameters로 전달
-export default function common(envVars = {}) {
+export default function common(envVars = {}, mode = 'development') {
   return {
     entry: './main.tsx',
     output: {
@@ -63,12 +63,12 @@ export default function common(envVars = {}) {
         patterns: [
           {
             from:
-              process.env.NODE_ENV === 'production'
+              mode === 'production'
                 ? 'public/robots-prod.txt'
                 : 'public/robots-dev.txt',
             to: 'robots.txt',
           },
-          ...(process.env.NODE_ENV === 'production'
+          ...(mode === 'production'
             ? [
                 {
                   from: 'public/sitemap.xml',

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -18,7 +18,7 @@ const defineEnv = Object.entries(envVars).reduce(
   { 'process.env.NODE_ENV': JSON.stringify(mode) },
 );
 
-export default merge(common(envVars), {
+export default merge(common(envVars, mode), {
   mode,
   devtool: 'eval-cheap-module-source-map',
   devServer: {

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -21,7 +21,7 @@ const defineEnv = Object.entries(envVars).reduce(
   { 'process.env.NODE_ENV': JSON.stringify(mode) },
 );
 
-export default merge(common(envVars), {
+export default merge(common(envVars, mode), {
   mode,
   devtool: 'source-map',
   output: {


### PR DESCRIPTION
# #️⃣ Issue Number
#539 

## 🕹️ 작업 내용

한 줄 요약 : robots.txt 환경 분기 변수를 mode 파라미터로 변경하여 프로덕션 빌드 시 올바른 파일이 적용되도록 수정했습니다.

- [ ]
- [ ]

## 📋 리뷰 포인트

-
-

## 🔮 기타 사항

- prod로 올리고 올바른 robots-prod.txt(Allow: /)가 적용되는지 확인해보겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 웹팩 빌드 설정을 개선하여 개발 및 프로덕션 환경에서 모드 파라미터를 더 효율적으로 처리하도록 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->