### PR TITLE
fix: 전체 허용 및 동적 result 페이지만 차단하도록 robots.txt 수정

### DIFF
--- a/frontend/public/robots-prod.txt
+++ b/frontend/public/robots-prod.txt
@@ -1,9 +1,9 @@
 # 운영환경용 robots.txt
-# 홈페이지만 크롤링 허용, 동적 페이지(/result/:id 등)는 차단
+# 동적 페이지(/result/:id 등)만 차단, 나머지 허용
 
 User-agent: *
-Disallow: /
-Allow: /$
+Allow: /
+Disallow: /result
 
 # Sitemap 위치
 Sitemap: https://moitz.kr/sitemap.xml


### PR DESCRIPTION
# #️⃣ Issue Number

## 🕹️ 작업 내용

한 줄 요약 : robots.txt 허용 범위 변경

### AS-IS

```md
User-agent: *
Disallow: /
Allow: /$
```

### TO-BE

```md
User-agent: *
Allow: /
Disallow: /result
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기타 변경사항**
  * 검색 엔진의 사이트 크롤링 정책을 조정했습니다. 대부분의 경로에 대한 접근을 허용하도록 변경되었으며 특정 경로는 제외되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->