### PR TITLE
[BE] fix: 최소 환승 태그 기준 개선

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -60,6 +60,5 @@ dependencies {
 
 tasks.withType(Test).configureEach {
 	useJUnitPlatform()
-	systemProperty "spring.profiles.active",
-			System.getProperty("spring.profiles.active") ?: "test"
+	systemProperty "spring.profiles.active", "test"
 }

--- a/backend/src/main/java/com/f12/moitz/domain/FinalCandidateSelector.java
+++ b/backend/src/main/java/com/f12/moitz/domain/FinalCandidateSelector.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -43,9 +44,13 @@ public class FinalCandidateSelector {
         final List<Place> limitedSelectedPlaces = selectedPlaces.stream()
                 .limit(limit)
                 .toList();
+        final Map<Place, List<CandidateSelectionTag>> filteredTagsByPlace = filterTagsBySelectedPlaces(
+                tagsByPlace,
+                limitedSelectedPlaces
+        );
         return new FinalCandidateSelectionResult(
                 limitedSelectedPlaces,
-                filterTagsBySelectedPlaces(tagsByPlace, limitedSelectedPlaces)
+                normalizeTransferTags(candidateSelectionResult, limitedSelectedPlaces, filteredTagsByPlace)
         );
     }
 
@@ -176,6 +181,91 @@ public class FinalCandidateSelector {
         final Set<String> placeNames = new HashSet<>();
         places.forEach(place -> placeNames.add(place.getName()));
         return placeNames;
+    }
+
+    private Map<Place, List<CandidateSelectionTag>> normalizeTransferTags(
+            final CandidateSelectionResult candidateSelectionResult,
+            final List<Place> selectedPlaces,
+            final Map<Place, List<CandidateSelectionTag>> tagsByPlace
+    ) {
+        final Map<String, RouteCandidate> candidatesByPlaceName = candidatesByPlaceName(candidateSelectionResult);
+        final List<TransferScore> transferScores = selectedPlaces.stream()
+                .map(place -> candidatesByPlaceName.get(place.getName()))
+                .filter(Objects::nonNull)
+                .map(candidate -> TransferScore.from(candidate.calculateFairnessScore()))
+                .toList();
+
+        if (transferScores.isEmpty()) {
+            return tagsByPlace;
+        }
+
+        final TransferScore bestTransferScore = transferScores.stream()
+                .min(TransferScore::compareTo)
+                .orElseThrow();
+        final Map<Place, List<CandidateSelectionTag>> normalizedTagsByPlace = new LinkedHashMap<>();
+        selectedPlaces.forEach(place -> normalizedTagsByPlace.put(
+                place,
+                normalizeTransferTag(place, tagsByPlace, candidatesByPlaceName, bestTransferScore)
+        ));
+        return normalizedTagsByPlace;
+    }
+
+    private Map<String, RouteCandidate> candidatesByPlaceName(final CandidateSelectionResult candidateSelectionResult) {
+        final Map<String, RouteCandidate> candidatesByPlaceName = new LinkedHashMap<>();
+        candidateSelectionResult.getSelectedCandidates()
+                .forEach(candidate -> candidatesByPlaceName.putIfAbsent(candidate.getPlace().getName(), candidate));
+        candidateSelectionResult.getTagSelections()
+                .values()
+                .forEach(candidates -> candidates.forEach(candidate ->
+                        candidatesByPlaceName.putIfAbsent(candidate.getPlace().getName(), candidate)));
+        return candidatesByPlaceName;
+    }
+
+    private List<CandidateSelectionTag> normalizeTransferTag(
+            final Place place,
+            final Map<Place, List<CandidateSelectionTag>> tagsByPlace,
+            final Map<String, RouteCandidate> candidatesByPlaceName,
+            final TransferScore bestTransferScore
+    ) {
+        final List<CandidateSelectionTag> tags = tagsByPlace.getOrDefault(place, List.of(CandidateSelectionTag.GENERAL));
+        final RouteCandidate candidate = candidatesByPlaceName.get(place.getName());
+        final boolean isBestTransfer = candidate != null
+                && TransferScore.from(candidate.calculateFairnessScore()).compareTo(bestTransferScore) == 0;
+
+        if (isBestTransfer && tags.contains(CandidateSelectionTag.TRANSFER)) {
+            return tags;
+        }
+        return tags.stream()
+                .filter(tag -> tag != CandidateSelectionTag.TRANSFER)
+                .toList();
+    }
+
+    private record TransferScore(
+            double averageTransferCount,
+            int maxTransferCount,
+            int transferDiff
+    ) implements Comparable<TransferScore> {
+
+        private static TransferScore from(final FairnessScore fairnessScore) {
+            return new TransferScore(
+                    fairnessScore.getAverageTransferCount(),
+                    fairnessScore.getMaxTransferCount(),
+                    fairnessScore.getTransferDiff()
+            );
+        }
+
+        @Override
+        public int compareTo(final TransferScore other) {
+            final int averageComparison = Double.compare(averageTransferCount, other.averageTransferCount);
+            if (averageComparison != 0) {
+                return averageComparison;
+            }
+            if (maxTransferCount != other.maxTransferCount) {
+                return Integer.compare(maxTransferCount, other.maxTransferCount);
+            }
+            return Integer.compare(transferDiff, other.transferDiff);
+        }
+
     }
 
     private record TaggedPlaceSelection(

--- a/backend/src/main/java/com/f12/moitz/domain/FinalCandidateSelector.java
+++ b/backend/src/main/java/com/f12/moitz/domain/FinalCandidateSelector.java
@@ -202,12 +202,21 @@ public class FinalCandidateSelector {
         final TransferScore bestTransferScore = transferScores.stream()
                 .min(TransferScore::compareTo)
                 .orElseThrow();
+        final Set<String> transferCandidateNames = transferCandidateNames(candidateSelectionResult);
         final Map<Place, List<CandidateSelectionTag>> normalizedTagsByPlace = new LinkedHashMap<>();
         selectedPlaces.forEach(place -> normalizedTagsByPlace.put(
                 place,
-                normalizeTransferTag(place, tagsByPlace, candidatesByPlaceName, bestTransferScore)
+                normalizeTransferTag(place, tagsByPlace, candidatesByPlaceName, transferCandidateNames, bestTransferScore)
         ));
         return normalizedTagsByPlace;
+    }
+
+    private Set<String> transferCandidateNames(final CandidateSelectionResult candidateSelectionResult) {
+        final Set<String> transferCandidateNames = new HashSet<>();
+        candidateSelectionResult.getTagSelections()
+                .getOrDefault(CandidateSelectionTag.TRANSFER, List.of())
+                .forEach(candidate -> transferCandidateNames.add(candidate.getPlace().getName()));
+        return transferCandidateNames;
     }
 
     private Map<String, RouteCandidate> candidatesByPlaceName(final CandidateSelectionResult candidateSelectionResult) {
@@ -225,6 +234,7 @@ public class FinalCandidateSelector {
             final Place place,
             final Map<Place, List<CandidateSelectionTag>> tagsByPlace,
             final Map<String, RouteCandidate> candidatesByPlaceName,
+            final Set<String> transferCandidateNames,
             final TransferScore bestTransferScore
     ) {
         final List<CandidateSelectionTag> tags = tagsByPlace.getOrDefault(place, List.of(CandidateSelectionTag.GENERAL));
@@ -232,8 +242,13 @@ public class FinalCandidateSelector {
         final boolean isBestTransfer = candidate != null
                 && TransferScore.from(candidate.calculateFairnessScore()).compareTo(bestTransferScore) == 0;
 
-        if (isBestTransfer && tags.contains(CandidateSelectionTag.TRANSFER)) {
-            return tags;
+        if (isBestTransfer && transferCandidateNames.contains(place.getName())) {
+            if (tags.contains(CandidateSelectionTag.TRANSFER)) {
+                return tags;
+            }
+            final List<CandidateSelectionTag> tagsWithTransfer = new ArrayList<>(tags);
+            tagsWithTransfer.add(CandidateSelectionTag.TRANSFER);
+            return tagsWithTransfer;
         }
         return tags.stream()
                 .filter(tag -> tag != CandidateSelectionTag.TRANSFER)

--- a/backend/src/test/java/com/f12/moitz/domain/FinalCandidateSelectorTest.java
+++ b/backend/src/test/java/com/f12/moitz/domain/FinalCandidateSelectorTest.java
@@ -79,6 +79,81 @@ class FinalCandidateSelectorTest {
     }
 
     @Test
+    @DisplayName("최소 환승 태그는 최종 후보 중 환승 점수가 가장 낮은 후보에만 부여한다")
+    void select_AssignsTransferTagOnlyToBestTransferScoresAmongFinalPlaces() {
+        final RouteCandidate wangsimni = routeCandidateWithTransfers("왕십리역", List.of(0, 0, 2, 2));
+        final RouteCandidate oksu = routeCandidateWithTransfers("옥수역", List.of(0, 1, 0, 1));
+        final RouteCandidate yaksu = routeCandidateWithTransfers("약수역", List.of(1, 1, 0, 1));
+        final RouteCandidate chungmuro = routeCandidateWithTransfers("충무로역", List.of(2, 1, 0, 1));
+        final Map<CandidateSelectionTag, List<RouteCandidate>> tagSelections = new LinkedHashMap<>();
+        tagSelections.put(CandidateSelectionTag.FAIRNESS, List.of(wangsimni));
+        tagSelections.put(CandidateSelectionTag.MAX_BURDEN_RELIEF, List.of(oksu));
+        tagSelections.put(CandidateSelectionTag.EFFICIENCY, List.of(wangsimni, yaksu));
+        tagSelections.put(CandidateSelectionTag.TRANSFER, List.of(wangsimni, yaksu, oksu, chungmuro));
+        tagSelections.put(CandidateSelectionTag.GENERAL, List.of(chungmuro));
+        final CandidateSelectionResult candidateSelectionResult = new CandidateSelectionResult(
+                List.of(wangsimni, oksu, yaksu, chungmuro),
+                DispersionPolicy.TIER_4,
+                DispersionPolicy.TIER_4,
+                4,
+                false,
+                tagSelections
+        );
+
+        final FinalCandidateSelectionResult selectionResult = finalCandidateSelector.select(
+                candidateSelectionResult,
+                candidateSelectionResult.getSelectedPlaces(),
+                ignored -> true,
+                4
+        );
+
+        assertThat(selectionResult.getTags(wangsimni.getPlace()))
+                .containsExactly(CandidateSelectionTag.FAIRNESS, CandidateSelectionTag.EFFICIENCY);
+        assertThat(selectionResult.getTags(oksu.getPlace()))
+                .containsExactly(CandidateSelectionTag.MAX_BURDEN_RELIEF, CandidateSelectionTag.TRANSFER);
+        assertThat(selectionResult.getTags(yaksu.getPlace()))
+                .containsExactly(CandidateSelectionTag.EFFICIENCY);
+        assertThat(selectionResult.getTags(chungmuro.getPlace()))
+                .containsExactly(CandidateSelectionTag.GENERAL);
+    }
+
+    @Test
+    @DisplayName("최종 후보 중 같은 최소 환승 점수인 후보에는 최소 환승 태그를 함께 부여한다")
+    void select_AddsTransferTagToAllBestTransferScorePlaces() {
+        final RouteCandidate fairness = routeCandidateWithTransfers("공평후보역", List.of(0, 1));
+        final RouteCandidate general = routeCandidateWithTransfers("일반후보역", List.of(0, 1));
+        final RouteCandidate highTransfer = routeCandidateWithTransfers("환승많은역", List.of(1, 1));
+        final Map<CandidateSelectionTag, List<RouteCandidate>> tagSelections = new LinkedHashMap<>();
+        tagSelections.put(CandidateSelectionTag.FAIRNESS, List.of(fairness));
+        tagSelections.put(CandidateSelectionTag.MAX_BURDEN_RELIEF, List.of(highTransfer));
+        tagSelections.put(CandidateSelectionTag.EFFICIENCY, List.of());
+        tagSelections.put(CandidateSelectionTag.TRANSFER, List.of(fairness, general, highTransfer));
+        tagSelections.put(CandidateSelectionTag.GENERAL, List.of(general));
+        final CandidateSelectionResult candidateSelectionResult = new CandidateSelectionResult(
+                List.of(fairness, highTransfer, general),
+                DispersionPolicy.TIER_4,
+                DispersionPolicy.TIER_4,
+                3,
+                false,
+                tagSelections
+        );
+
+        final FinalCandidateSelectionResult selectionResult = finalCandidateSelector.select(
+                candidateSelectionResult,
+                candidateSelectionResult.getSelectedPlaces(),
+                ignored -> true,
+                3
+        );
+
+        assertThat(selectionResult.getTags(fairness.getPlace()))
+                .containsExactly(CandidateSelectionTag.FAIRNESS, CandidateSelectionTag.TRANSFER);
+        assertThat(selectionResult.getTags(general.getPlace()))
+                .containsExactly(CandidateSelectionTag.TRANSFER);
+        assertThat(selectionResult.getTags(highTransfer.getPlace()))
+                .containsExactly(CandidateSelectionTag.MAX_BURDEN_RELIEF);
+    }
+
+    @Test
     @DisplayName("다음 장소 검색 대상은 비어있는 태그 후보를 우선하고 이 후보가 남아있다면 일반 후보로 채우지 않는다")
     void selectNextSearchPlaces_PrioritizesMissingTagsWithoutGeneralFillWhenTagCandidatesRemain() {
         final RouteCandidate fairness = routeCandidate("공평후보역");
@@ -177,6 +252,34 @@ class FinalCandidateSelectorTest {
                         SubwayLine.fromTitle("2호선")
                 )))))
         );
+    }
+
+    private RouteCandidate routeCandidateWithTransfers(final String name, final List<Integer> transferCounts) {
+        final Place end = place(name);
+        final List<Route> routes = java.util.stream.IntStream.range(0, transferCounts.size())
+                .mapToObj(index -> routeWithTransfers(
+                        new Place("출발" + index + "역", new Point(127.0 + index, 37.0 + index)),
+                        end,
+                        transferCounts.get(index)
+                ))
+                .toList();
+        return new RouteCandidate(end, new Routes(routes));
+    }
+
+    private Route routeWithTransfers(final Place start, final Place end, final int transferCount) {
+        final List<Path> paths = new java.util.ArrayList<>();
+        Place currentStart = start;
+        for (int index = 0; index < transferCount; index++) {
+            final Place transferStation = new Place(
+                    start.getName() + "환승" + index,
+                    new Point(127.4 + index, 37.4 + index)
+            );
+            paths.add(new Path(currentStart, transferStation, TravelMethod.SUBWAY, 0, SubwayLine.fromTitle("2호선")));
+            paths.add(new Path(transferStation, transferStation, TravelMethod.TRANSFER, 0, null));
+            currentStart = transferStation;
+        }
+        paths.add(new Path(currentStart, end, TravelMethod.SUBWAY, 20 * 60, SubwayLine.fromTitle("3호선")));
+        return new Route(paths);
     }
 
     private Place place(final String name) {

--- a/backend/src/test/java/com/f12/moitz/domain/FinalCandidateSelectorTest.java
+++ b/backend/src/test/java/com/f12/moitz/domain/FinalCandidateSelectorTest.java
@@ -154,6 +154,39 @@ class FinalCandidateSelectorTest {
     }
 
     @Test
+    @DisplayName("최소 환승 후보가 기존 태그 수집에서 누락되어도 최종 태그 정규화에서 최소 환승 태그를 부여한다")
+    void select_AddsTransferTagWhenBestTransferPlaceWasNotCollectedAsTransferTag() {
+        final RouteCandidate bestTransfer = routeCandidateWithTransfers("최소환승역", List.of(0, 1));
+        final RouteCandidate taggedTransfer = routeCandidateWithTransfers("태그수집환승역", List.of(1, 1));
+        final Map<CandidateSelectionTag, List<RouteCandidate>> tagSelections = new LinkedHashMap<>();
+        tagSelections.put(CandidateSelectionTag.FAIRNESS, List.of(bestTransfer));
+        tagSelections.put(CandidateSelectionTag.MAX_BURDEN_RELIEF, List.of());
+        tagSelections.put(CandidateSelectionTag.EFFICIENCY, List.of());
+        tagSelections.put(CandidateSelectionTag.TRANSFER, List.of(taggedTransfer, bestTransfer));
+        tagSelections.put(CandidateSelectionTag.GENERAL, List.of());
+        final CandidateSelectionResult candidateSelectionResult = new CandidateSelectionResult(
+                List.of(bestTransfer, taggedTransfer),
+                DispersionPolicy.TIER_4,
+                DispersionPolicy.TIER_4,
+                2,
+                false,
+                tagSelections
+        );
+
+        final FinalCandidateSelectionResult selectionResult = finalCandidateSelector.select(
+                candidateSelectionResult,
+                candidateSelectionResult.getSelectedPlaces(),
+                ignored -> true,
+                2
+        );
+
+        assertThat(selectionResult.getTags(bestTransfer.getPlace()))
+                .containsExactly(CandidateSelectionTag.FAIRNESS, CandidateSelectionTag.TRANSFER);
+        assertThat(selectionResult.getTags(taggedTransfer.getPlace()))
+                .containsExactly(CandidateSelectionTag.GENERAL);
+    }
+
+    @Test
     @DisplayName("다음 장소 검색 대상은 비어있는 태그 후보를 우선하고 이 후보가 남아있다면 일반 후보로 채우지 않는다")
     void selectNextSearchPlaces_PrioritizesMissingTagsWithoutGeneralFillWhenTagCandidatesRemain() {
         final RouteCandidate fairness = routeCandidate("공평후보역");

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,3 +1,8 @@
 spring.redis.host=unused
 monitoring.namespace=Moitz2025Test
 spring.data.mongodb.auto-index-creation=false
+kakao.api.key=dummy
+gemini.api.key=dummy
+odsay.api.key=dummy
+perplexity.api.key=dummy
+open.api.key=dummy


### PR DESCRIPTION
## 🕹️ 작업 내용

기존 최소 환승 태그는 말 그대로 "환승이 최소"인 경우에 붙어야 하는데, 그렇지 않은 케이스에서도 추가되는 현상 개선
-> 환승이 적은 후보풀에서 추천 지역을 뽑아낸 후 "최소"가 맞는지 검증하지 않고, 후보풀의 이름을 그대로 가져왔기 때문에 발생



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 테스트 환경 설정 및 인프라 개선
  * 선택된 장소에 대한 태그 할당 로직 최적화
  * 테스트 커버리지 확대 및 외부 서비스 테스트 설정 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->