### PR TITLE
[BE] feat: 추천 지역 단일 태그 매핑 및 공평성 점수 기준 정렬 적용

### DIFF
--- a/backend/src/main/java/com/f12/moitz/application/dto/recommendation/LocationResponse.java
+++ b/backend/src/main/java/com/f12/moitz/application/dto/recommendation/LocationResponse.java
@@ -1,6 +1,8 @@
 package com.f12.moitz.application.dto.recommendation;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.f12.moitz.domain.recommendation.RecommendCondition;
+import com.f12.moitz.domain.recommendation.candidate.CandidateSelectionTag;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.Map;
@@ -23,10 +25,16 @@ public record LocationResponse(
         boolean isBest,
         @Schema(description = "추천 태그 코드 목록", example = "[\"FAIRNESS\"]", requiredMode = Schema.RequiredMode.REQUIRED)
         List<String> tags,
+        @JsonProperty("tag_info")
+        @Schema(description = "추천 태그 설명", example = "환승 부담이 적은 기준", requiredMode = Schema.RequiredMode.REQUIRED)
+        String tagInfo,
         @Schema(description = "추천 이유 해시태그", example = "#최소환승", requiredMode = Schema.RequiredMode.REQUIRED)
         String description,
         @Schema(description = "지역 추천 이유 문장", example = "서울역은 환승 부담이 적은 기준을 반영해 추천된 만남 장소입니다.", requiredMode = Schema.RequiredMode.REQUIRED)
         String reason,
+        @JsonProperty("location_info")
+        @Schema(description = "지역 추천 정보", example = "서울역은 환승 부담이 적은 기준을 반영해 추천된 만남 장소입니다.", requiredMode = Schema.RequiredMode.REQUIRED)
+        String locationInfo,
         @Schema(
                 description = "카테고리별 추천 장소 목록",
                 example = """
@@ -108,7 +116,41 @@ public record LocationResponse(
                 avgMinutes,
                 isBest,
                 List.of(validateTag(tag)),
+                resolveTagInfo(tag),
                 description,
+                reason,
+                reason,
+                places,
+                routes
+        );
+    }
+
+    public LocationResponse(
+            final Long id,
+            final int index,
+            final double y,
+            final double x,
+            final String name,
+            final int avgMinutes,
+            final boolean isBest,
+            final List<String> tags,
+            final String description,
+            final String reason,
+            final Map<RecommendCondition, List<PlaceRecommendResponse>> places,
+            final List<RouteResponse> routes
+    ) {
+        this(
+                id,
+                index,
+                y,
+                x,
+                name,
+                avgMinutes,
+                isBest,
+                validateTags(tags),
+                resolveTagInfo(tags),
+                description,
+                reason,
                 reason,
                 places,
                 routes
@@ -120,6 +162,23 @@ public record LocationResponse(
             throw new IllegalArgumentException("추천 태그는 비어 있을 수 없습니다.");
         }
         return tag;
+    }
+
+    private static List<String> validateTags(final List<String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            throw new IllegalArgumentException("추천 태그는 비어 있을 수 없습니다.");
+        }
+        return tags.stream()
+                .map(LocationResponse::validateTag)
+                .toList();
+    }
+
+    private static String resolveTagInfo(final List<String> tags) {
+        return resolveTagInfo(validateTags(tags).getFirst());
+    }
+
+    private static String resolveTagInfo(final String tag) {
+        return CandidateSelectionTag.valueOf(validateTag(tag)).getDescription();
     }
 
 }

--- a/backend/src/main/java/com/f12/moitz/application/dto/recommendation/LocationResponse.java
+++ b/backend/src/main/java/com/f12/moitz/application/dto/recommendation/LocationResponse.java
@@ -21,11 +21,11 @@ public record LocationResponse(
         int avgMinutes,
         @Schema(description = "최적의 추천 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
         boolean isBest,
-        @Schema(description = "추천 태그 코드 목록", example = "[\"FAIRNESS\", \"EFFICIENCY\"]", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "추천 태그 코드 목록", example = "[\"FAIRNESS\"]", requiredMode = Schema.RequiredMode.REQUIRED)
         List<String> tags,
-        @Schema(description = "추천 이유 해시태그", example = "#최소환승 #평균최소", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "추천 이유 해시태그", example = "#최소환승", requiredMode = Schema.RequiredMode.REQUIRED)
         String description,
-        @Schema(description = "지역 추천 이유 문장", example = "서울역은 환승 부담이 적은 기준, 전체 참여자의 평균 이동 시간이 짧은 기준을 반영해 추천된 만남 장소입니다.", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "지역 추천 이유 문장", example = "서울역은 환승 부담이 적은 기준을 반영해 추천된 만남 장소입니다.", requiredMode = Schema.RequiredMode.REQUIRED)
         String reason,
         @Schema(
                 description = "카테고리별 추천 장소 목록",

--- a/backend/src/main/java/com/f12/moitz/application/dto/recommendation/LocationResponse.java
+++ b/backend/src/main/java/com/f12/moitz/application/dto/recommendation/LocationResponse.java
@@ -165,17 +165,17 @@ public record LocationResponse(
 
     private static String validateTag(final String tag) {
         if (tag == null || tag.isBlank()) {
-            throw new IllegalArgumentException("추천 태그는 비어 있을 수 없습니다.");
+            throw new BadRequestException(GeneralErrorCode.INPUT_INVALID_RECOMMENDATION_TAG, tag);
         }
         return tag;
     }
 
     private static List<String> validateTags(final List<String> tags) {
         if (tags == null || tags.isEmpty()) {
-            throw new IllegalArgumentException("추천 태그는 비어 있을 수 없습니다.");
+            throw new BadRequestException(GeneralErrorCode.INPUT_INVALID_RECOMMENDATION_TAG, tags);
         }
         if (tags.size() != 1) {
-            throw new IllegalArgumentException("추천 태그는 하나만 가질 수 있습니다.");
+            throw new BadRequestException(GeneralErrorCode.INPUT_INVALID_RECOMMENDATION_TAG, tags);
         }
         return tags.stream()
                 .map(LocationResponse::validateTag)

--- a/backend/src/main/java/com/f12/moitz/application/dto/recommendation/LocationResponse.java
+++ b/backend/src/main/java/com/f12/moitz/application/dto/recommendation/LocationResponse.java
@@ -93,6 +93,10 @@ public record LocationResponse(
         List<RouteResponse> routes
 ) {
 
+    public LocationResponse {
+        tags = validateTags(tags);
+    }
+
     public LocationResponse(
             final Long id,
             final int index,
@@ -167,6 +171,9 @@ public record LocationResponse(
     private static List<String> validateTags(final List<String> tags) {
         if (tags == null || tags.isEmpty()) {
             throw new IllegalArgumentException("추천 태그는 비어 있을 수 없습니다.");
+        }
+        if (tags.size() != 1) {
+            throw new IllegalArgumentException("추천 태그는 하나만 가질 수 있습니다.");
         }
         return tags.stream()
                 .map(LocationResponse::validateTag)

--- a/backend/src/main/java/com/f12/moitz/application/dto/recommendation/LocationResponse.java
+++ b/backend/src/main/java/com/f12/moitz/application/dto/recommendation/LocationResponse.java
@@ -1,6 +1,8 @@
 package com.f12.moitz.application.dto.recommendation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.f12.moitz.common.error.exception.BadRequestException;
+import com.f12.moitz.common.error.exception.GeneralErrorCode;
 import com.f12.moitz.domain.recommendation.RecommendCondition;
 import com.f12.moitz.domain.recommendation.candidate.CandidateSelectionTag;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -185,7 +187,12 @@ public record LocationResponse(
     }
 
     private static String resolveTagInfo(final String tag) {
-        return CandidateSelectionTag.valueOf(validateTag(tag)).getDescription();
+        final String validatedTag = validateTag(tag);
+        try {
+            return CandidateSelectionTag.valueOf(validatedTag).getDescription();
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException(GeneralErrorCode.INPUT_INVALID_RECOMMENDATION_TAG, e, validatedTag);
+        }
     }
 
 }

--- a/backend/src/main/java/com/f12/moitz/application/port/place/PlaceRecommendationCriteria.java
+++ b/backend/src/main/java/com/f12/moitz/application/port/place/PlaceRecommendationCriteria.java
@@ -1,0 +1,27 @@
+package com.f12.moitz.application.port.place;
+
+import com.f12.moitz.common.error.exception.BadRequestException;
+import com.f12.moitz.common.error.exception.GeneralErrorCode;
+import com.f12.moitz.domain.recommendation.RecommendCondition;
+import java.util.List;
+import java.util.Objects;
+
+public record PlaceRecommendationCriteria(
+        List<RecommendCondition> conditions,
+        int limitPerCondition
+) {
+
+    public PlaceRecommendationCriteria {
+        if (conditions == null || conditions.isEmpty()) {
+            throw new BadRequestException(GeneralErrorCode.INPUT_INVALID_DESCRIPTION, conditions);
+        }
+        if (conditions.stream().anyMatch(Objects::isNull)) {
+            throw new BadRequestException(GeneralErrorCode.INPUT_INVALID_DESCRIPTION, conditions);
+        }
+        if (limitPerCondition < 1) {
+            throw new IllegalArgumentException("추천 장소 개수는 1개 이상이어야 합니다.");
+        }
+        conditions = List.copyOf(conditions);
+    }
+
+}

--- a/backend/src/main/java/com/f12/moitz/application/port/place/PlaceRecommendationCriteria.java
+++ b/backend/src/main/java/com/f12/moitz/application/port/place/PlaceRecommendationCriteria.java
@@ -13,11 +13,12 @@ public record PlaceRecommendationCriteria(
 
     public PlaceRecommendationCriteria {
         if (conditions == null || conditions.isEmpty()) {
-            throw new BadRequestException(GeneralErrorCode.INPUT_INVALID_DESCRIPTION, conditions);
+            throw new BadRequestException(GeneralErrorCode.INPUT_INVALID_RECOMMEND_CONDITION, conditions);
         }
         if (conditions.stream().anyMatch(Objects::isNull)) {
-            throw new BadRequestException(GeneralErrorCode.INPUT_INVALID_DESCRIPTION, conditions);
+            throw new BadRequestException(GeneralErrorCode.INPUT_INVALID_RECOMMEND_CONDITION, conditions);
         }
+        // Programmer invariant: limitPerCondition is provided by application policy, not user input.
         if (limitPerCondition < 1) {
             throw new IllegalArgumentException("추천 장소 개수는 1개 이상이어야 합니다.");
         }

--- a/backend/src/main/java/com/f12/moitz/application/port/place/PlaceRecommender.java
+++ b/backend/src/main/java/com/f12/moitz/application/port/place/PlaceRecommender.java
@@ -2,12 +2,14 @@ package com.f12.moitz.application.port.place;
 
 import com.f12.moitz.domain.recommendation.RecommendedPlaces;
 import com.f12.moitz.domain.place.Place;
-import com.f12.moitz.domain.recommendation.RecommendCondition;
 import java.util.List;
 import java.util.Map;
 
 public interface PlaceRecommender {
 
-    Map<Place, RecommendedPlaces> recommendPlaces(List<Place> targetPlaces, List<RecommendCondition> requirements);
+    Map<Place, RecommendedPlaces> recommendPlaces(
+            List<Place> targetPlaces,
+            PlaceRecommendationCriteria criteria
+    );
 
 }

--- a/backend/src/main/java/com/f12/moitz/application/recommendation/RecommendationPlaceSearchService.java
+++ b/backend/src/main/java/com/f12/moitz/application/recommendation/RecommendationPlaceSearchService.java
@@ -1,6 +1,7 @@
 package com.f12.moitz.application.recommendation;
 
 import com.f12.moitz.application.port.place.PlaceRecommender;
+import com.f12.moitz.application.port.place.PlaceRecommendationCriteria;
 import com.f12.moitz.domain.recommendation.candidate.CandidateSelection;
 import com.f12.moitz.domain.recommendation.RecommendedPlaces;
 import com.f12.moitz.domain.recommendation.RecommendedCandidates;
@@ -33,8 +34,13 @@ public class RecommendationPlaceSearchService {
             final List<RecommendCondition> recommendConditions,
             final Map<Place, Routes> candidateRoutes,
             final int searchLimit,
+            final int recommendedPlaceLimitPerCondition,
             final int targetCount
     ) {
+        final PlaceRecommendationCriteria criteria = new PlaceRecommendationCriteria(
+                recommendConditions,
+                recommendedPlaceLimitPerCondition
+        );
         final Map<Place, RecommendedPlaces> accumulatedRecommendedPlaces = new LinkedHashMap<>();
         final List<Place> searchedPlaces = new ArrayList<>();
         RecommendedCandidates recommendedCandidates = selectRecommendedCandidates(
@@ -72,7 +78,7 @@ public class RecommendationPlaceSearchService {
                     summarizePlacesWithScore(batch, candidateRoutes)
             );
 
-            accumulatedRecommendedPlaces.putAll(placeRecommender.recommendPlaces(batch, recommendConditions));
+            accumulatedRecommendedPlaces.putAll(placeRecommender.recommendPlaces(batch, criteria));
             searchedPlaces.addAll(batch);
 
             recommendedCandidates = selectRecommendedCandidates(

--- a/backend/src/main/java/com/f12/moitz/application/recommendation/RecommendationService.java
+++ b/backend/src/main/java/com/f12/moitz/application/recommendation/RecommendationService.java
@@ -300,7 +300,7 @@ public class RecommendationService {
 
     private void validateRecommendationCandidates(final RecommendedCandidates recommendedCandidates) {
         if (recommendedCandidates.isEmpty()) {
-            throw new BadRequestException(GeneralErrorCode.RECOMMENDATION_NOT_FOUND);
+            throw new BadRequestException(GeneralErrorCode.RECOMMENDATION_RESULT_EMPTY);
         }
     }
 

--- a/backend/src/main/java/com/f12/moitz/application/recommendation/RecommendationService.java
+++ b/backend/src/main/java/com/f12/moitz/application/recommendation/RecommendationService.java
@@ -43,6 +43,7 @@ public class RecommendationService {
 
     private static final int PLACE_SEARCH_POOL_LIMIT = 50;
     private static final int RECOMMENDED_CANDIDATE_TARGET_COUNT = 5;
+    private static final int RECOMMENDED_PLACE_LIMIT_PER_CONDITION = 6;
 
     private final SubwayStationService subwayStationService;
     private final SubwayRouteService subwayRouteService;
@@ -239,6 +240,7 @@ public class RecommendationService {
                 recommendConditions,
                 candidateRoutes,
                 PLACE_SEARCH_POOL_LIMIT,
+                RECOMMENDED_PLACE_LIMIT_PER_CONDITION,
                 RECOMMENDED_CANDIDATE_TARGET_COUNT
         );
     }

--- a/backend/src/main/java/com/f12/moitz/application/recommendation/utils/RecommendationResponseMapper.java
+++ b/backend/src/main/java/com/f12/moitz/application/recommendation/utils/RecommendationResponseMapper.java
@@ -8,6 +8,7 @@ import com.f12.moitz.application.dto.recommendation.RecommendationResultResponse
 import com.f12.moitz.application.dto.recommendation.RouteResponse;
 import com.f12.moitz.application.dto.recommendation.StartingPlaceResponse;
 import com.f12.moitz.domain.recommendation.Candidate;
+import com.f12.moitz.domain.recommendation.RecommendationReason;
 import com.f12.moitz.domain.route.CandidateRoute;
 import com.f12.moitz.domain.recommendation.candidate.CandidateSelectionTag;
 import com.f12.moitz.domain.recommendation.RecommendedPlaces;
@@ -75,6 +76,11 @@ public class RecommendationResponseMapper {
                 candidate.getRecommendedPlaces()
         );
         final List<RouteResponse> routes = toRouteResponses(candidate);
+        final List<CandidateSelectionTag> tags = candidate.getTags();
+        final RecommendationReason recommendationReason = RecommendationReason.fromSelectionTags(
+                targetPlace.getName(),
+                tags
+        );
 
         return new LocationResponse(
                 (long) index + 1,
@@ -85,11 +91,11 @@ public class RecommendationResponseMapper {
                 totalTime,
                 // 추천 방식 변경으로 기존 평균 이동시간 기준 best 표시는 임시 비활성화한다.
                 BEST_RECOMMENDATION_DISABLED,
-                candidate.getTags().stream()
+                tags.stream()
                         .map(CandidateSelectionTag::name)
                         .toList(),
-                candidate.getDescription(),
-                candidate.getReason(),
+                recommendationReason.description(),
+                recommendationReason.reason(),
                 recommendedPlaces,
                 routes
         );

--- a/backend/src/main/java/com/f12/moitz/common/error/exception/BadRequestException.java
+++ b/backend/src/main/java/com/f12/moitz/common/error/exception/BadRequestException.java
@@ -18,4 +18,9 @@ public class BadRequestException extends RuntimeException {
         this.errorCode = errorCode;
     }
 
+    public BadRequestException(ErrorCode errorCode, Throwable cause, Object... args) {
+        super(errorCode.getMessage() + " " + Arrays.toString(args), cause);
+        this.errorCode = errorCode;
+    }
+
 }

--- a/backend/src/main/java/com/f12/moitz/common/error/exception/GeneralErrorCode.java
+++ b/backend/src/main/java/com/f12/moitz/common/error/exception/GeneralErrorCode.java
@@ -8,7 +8,7 @@ public enum GeneralErrorCode implements ErrorCode {
     INPUT_INVALID_DESCRIPTION("C0003", "유효하지 않은 성격입니다."),
     INPUT_INVALID_RESULT("C0004", "존재하지 않거나 유효 기간이 만료된 추천 결과입니다."),
     INPUT_INVALID_CANDIDATE_NAME("C0005", "유효하지 않은 추천 지역입니다."),
-    RECOMMENDATION_NOT_FOUND("C0006", "조건에 맞는 추천 결과를 찾지 못했습니다."),
+    RECOMMENDATION_RESULT_EMPTY("C0006", "조건에 맞는 추천 결과를 찾지 못했습니다."),
     INPUT_INVALID_RECOMMENDATION_TAG("C0007", "유효하지 않은 추천 태그입니다."),
     INPUT_INVALID_RECOMMEND_CONDITION("C0008", "유효하지 않은 추천 조건입니다.");
 

--- a/backend/src/main/java/com/f12/moitz/common/error/exception/GeneralErrorCode.java
+++ b/backend/src/main/java/com/f12/moitz/common/error/exception/GeneralErrorCode.java
@@ -9,7 +9,8 @@ public enum GeneralErrorCode implements ErrorCode {
     INPUT_INVALID_RESULT("C0004", "존재하지 않거나 유효 기간이 만료된 추천 결과입니다."),
     INPUT_INVALID_CANDIDATE_NAME("C0005", "유효하지 않은 추천 지역입니다."),
     RECOMMENDATION_NOT_FOUND("C0006", "조건에 맞는 추천 결과를 찾지 못했습니다."),
-    INPUT_INVALID_RECOMMENDATION_TAG("C0007", "유효하지 않은 추천 태그입니다.");
+    INPUT_INVALID_RECOMMENDATION_TAG("C0007", "유효하지 않은 추천 태그입니다."),
+    INPUT_INVALID_RECOMMEND_CONDITION("C0008", "유효하지 않은 추천 조건입니다.");
 
     private final String code;
     private final String message;

--- a/backend/src/main/java/com/f12/moitz/common/error/exception/GeneralErrorCode.java
+++ b/backend/src/main/java/com/f12/moitz/common/error/exception/GeneralErrorCode.java
@@ -8,7 +8,8 @@ public enum GeneralErrorCode implements ErrorCode {
     INPUT_INVALID_DESCRIPTION("C0003", "유효하지 않은 성격입니다."),
     INPUT_INVALID_RESULT("C0004", "존재하지 않거나 유효 기간이 만료된 추천 결과입니다."),
     INPUT_INVALID_CANDIDATE_NAME("C0005", "유효하지 않은 추천 지역입니다."),
-    RECOMMENDATION_NOT_FOUND("C0006", "조건에 맞는 추천 결과를 찾지 못했습니다.");
+    RECOMMENDATION_NOT_FOUND("C0006", "조건에 맞는 추천 결과를 찾지 못했습니다."),
+    INPUT_INVALID_RECOMMENDATION_TAG("C0007", "유효하지 않은 추천 태그입니다.");
 
     private final String code;
     private final String message;

--- a/backend/src/main/java/com/f12/moitz/domain/recommendation/Recommendation.java
+++ b/backend/src/main/java/com/f12/moitz/domain/recommendation/Recommendation.java
@@ -25,7 +25,7 @@ public class Recommendation {
                         getRecommendationReason(place, reasonsByPlace),
                         recommendedPlaces.get(place),
                         recommendedCandidateTravels.getCandidateRoutes(place),
-                        recommendedCandidates.getTags(place)
+                        List.of(recommendedCandidates.getTag(place))
                 ))
                 .toList();
         return new Recommendation(candidates);

--- a/backend/src/main/java/com/f12/moitz/domain/recommendation/Recommendation.java
+++ b/backend/src/main/java/com/f12/moitz/domain/recommendation/Recommendation.java
@@ -58,8 +58,8 @@ public class Recommendation {
 
     private List<Candidate> sort(final List<Candidate> candidates) {
         return candidates.stream()
-                .sorted(Comparator.comparingInt((Candidate candidate) -> candidate.getTag().getPriority())
-                        .thenComparing(Candidate::calculateFairnessScore))
+                .sorted(Comparator.comparing(Candidate::calculateFairnessScore)
+                        .thenComparingInt(candidate -> candidate.getTag().getPriority()))
                 .toList();
     }
 

--- a/backend/src/main/java/com/f12/moitz/domain/recommendation/RecommendedCandidates.java
+++ b/backend/src/main/java/com/f12/moitz/domain/recommendation/RecommendedCandidates.java
@@ -13,11 +13,11 @@ import java.util.stream.Collectors;
 public class RecommendedCandidates {
 
     private final List<Place> recommendedCandidatePlaces;
-    private final Map<Place, List<CandidateSelectionTag>> tagsByPlace;
+    private final Map<Place, CandidateSelectionTag> tagsByPlace;
 
     public RecommendedCandidates(
             final List<Place> recommendedCandidatePlaces,
-            final Map<Place, List<CandidateSelectionTag>> tagsByPlace
+            final Map<Place, CandidateSelectionTag> tagsByPlace
     ) {
         validate(recommendedCandidatePlaces, tagsByPlace);
         this.recommendedCandidatePlaces = List.copyOf(recommendedCandidatePlaces);
@@ -26,7 +26,7 @@ public class RecommendedCandidates {
 
     private void validate(
             final List<Place> recommendedCandidatePlaces,
-            final Map<Place, List<CandidateSelectionTag>> tagsByPlace
+            final Map<Place, CandidateSelectionTag> tagsByPlace
     ) {
         if (recommendedCandidatePlaces == null) {
             throw new IllegalArgumentException("추천 후보 목록은 null일 수 없습니다.");
@@ -40,10 +40,6 @@ public class RecommendedCandidates {
     }
 
     public CandidateSelectionTag getTag(final Place place) {
-        return getTags(place).get(0);
-    }
-
-    public List<CandidateSelectionTag> getTags(final Place place) {
         validateRecommendedCandidatePlace(place);
         return tagsByPlace.get(place);
     }
@@ -58,20 +54,20 @@ public class RecommendedCandidates {
                 .toList();
     }
 
-    public Map<String, List<CandidateSelectionTag>> getTagsByPlaceName() {
-        final Map<String, List<CandidateSelectionTag>> tagsByPlaceName = new LinkedHashMap<>();
-        recommendedCandidatePlaces.forEach(place -> tagsByPlaceName.put(
+    public Map<String, CandidateSelectionTag> getTagByPlaceName() {
+        final Map<String, CandidateSelectionTag> tagByPlaceName = new LinkedHashMap<>();
+        recommendedCandidatePlaces.forEach(place -> tagByPlaceName.put(
                 place.getName(),
-                getTags(place)
+                getTag(place)
         ));
-        return Collections.unmodifiableMap(tagsByPlaceName);
+        return Collections.unmodifiableMap(tagByPlaceName);
     }
 
     public Map<Place, RecommendationReason> createReasons() {
         return recommendedCandidatePlaces.stream()
                 .collect(Collectors.toMap(
                         Function.identity(),
-                        place -> RecommendationReason.fromSelectionTags(place.getName(), getTags(place)),
+                        place -> RecommendationReason.fromSelectionTags(place.getName(), List.of(getTag(place))),
                         (left, right) -> left,
                         LinkedHashMap::new
                 ));
@@ -94,16 +90,23 @@ public class RecommendedCandidates {
         }
     }
 
-    private Map<Place, List<CandidateSelectionTag>> normalizeTagsByPlace(
+    private Map<Place, CandidateSelectionTag> normalizeTagsByPlace(
             final List<Place> recommendedCandidatePlaces,
-            final Map<Place, List<CandidateSelectionTag>> tagsByPlace
+            final Map<Place, CandidateSelectionTag> tagsByPlace
     ) {
-        final Map<Place, List<CandidateSelectionTag>> normalizedTagsByPlace = new LinkedHashMap<>();
+        final Map<Place, CandidateSelectionTag> normalizedTagsByPlace = new LinkedHashMap<>();
         recommendedCandidatePlaces.forEach(place -> normalizedTagsByPlace.put(
                 place,
-                CandidateSelectionTag.normalize(tagsByPlace.get(place))
+                normalizeTag(tagsByPlace.get(place))
         ));
         return Collections.unmodifiableMap(normalizedTagsByPlace);
+    }
+
+    private CandidateSelectionTag normalizeTag(final CandidateSelectionTag tag) {
+        if (tag == null) {
+            return CandidateSelectionTag.normalize(null).getFirst();
+        }
+        return CandidateSelectionTag.normalize(List.of(tag)).getFirst();
     }
 
 }

--- a/backend/src/main/java/com/f12/moitz/domain/recommendation/candidate/CandidatePlaceSearchPolicy.java
+++ b/backend/src/main/java/com/f12/moitz/domain/recommendation/candidate/CandidatePlaceSearchPolicy.java
@@ -109,7 +109,7 @@ public class CandidatePlaceSearchPolicy {
 
         final List<Place> recommendedCandidatePlaces = taggedPlaceSelection.recommendedCandidatePlaces();
         final Set<Place> recommendedCandidatePlaceSet = toPlaceSet(recommendedCandidatePlaces);
-        final Map<Place, List<CandidateSelectionTag>> tagsByPlace = taggedPlaceSelection.tagsByPlace();
+        final Map<Place, CandidateSelectionTag> tagsByPlace = taggedPlaceSelection.tagsByPlace();
 
         for (Place place : searchedPlaces) {
             if (recommendedCandidatePlaceSet.contains(place) || !placeCondition.test(place)) {
@@ -117,7 +117,7 @@ public class CandidatePlaceSearchPolicy {
             }
             recommendedCandidatePlaces.add(place);
             selectedByTag.put(CandidateSelectionTag.GENERAL, place);
-            tagsByPlace.put(place, List.of(CandidateSelectionTag.GENERAL));
+            tagsByPlace.put(place, CandidateSelectionTag.GENERAL);
             return;
         }
     }
@@ -134,7 +134,7 @@ public class CandidatePlaceSearchPolicy {
         final Set<Place> searchedPlaceSet = toPlaceSet(searchedPlaces);
         final Set<Place> selectedPlaceSet = new HashSet<>();
         final Map<CandidateSelectionTag, Place> selectedByTag = new LinkedHashMap<>();
-        final Map<Place, List<CandidateSelectionTag>> tagsByPlace = new LinkedHashMap<>();
+        final Map<Place, CandidateSelectionTag> tagsByPlace = new LinkedHashMap<>();
 
         for (CandidateSelectionTag tag : CandidateSelectionTag.orderedValues()) {
             final List<RouteCandidate> tagCandidates = candidateSelection.getCandidatesByTag(tag);
@@ -148,7 +148,7 @@ public class CandidatePlaceSearchPolicy {
                 }
                 selectedByTag.put(tag, place);
                 selectedPlaceSet.add(place);
-                tagsByPlace.put(place, List.of(tag));
+                tagsByPlace.put(place, tag);
                 break;
             }
         }
@@ -167,7 +167,7 @@ public class CandidatePlaceSearchPolicy {
     private record TaggedPlaceSelection(
             List<Place> recommendedCandidatePlaces,
             Map<CandidateSelectionTag, Place> selectedByTag,
-            Map<Place, List<CandidateSelectionTag>> tagsByPlace
+            Map<Place, CandidateSelectionTag> tagsByPlace
     ) {
 
     }

--- a/backend/src/main/java/com/f12/moitz/domain/recommendation/candidate/CandidatePlaceSearchPolicy.java
+++ b/backend/src/main/java/com/f12/moitz/domain/recommendation/candidate/CandidatePlaceSearchPolicy.java
@@ -61,7 +61,7 @@ public class CandidatePlaceSearchPolicy {
                     .ifPresent(place -> nextSearchPlaces.putIfAbsent(place, place));
         }
 
-        if (!nextSearchPlaces.isEmpty() || selectedByTag.containsKey(CandidateSelectionTag.GENERAL)) {
+        if (!nextSearchPlaces.isEmpty() || hasGeneralSelection(selectedByTag)) {
             return nextSearchPlaces.values().stream()
                     .limit(limit)
                     .toList();
@@ -93,31 +93,37 @@ public class CandidatePlaceSearchPolicy {
                 searchedPlaces,
                 placeCondition
         );
-        final List<Place> recommendedCandidatePlaces = new ArrayList<>(taggedPlaceSelection.recommendedCandidatePlaces());
-        final Map<CandidateSelectionTag, Place> selectedByTag = new LinkedHashMap<>(
-                taggedPlaceSelection.selectedByTag()
-        );
-        final Map<Place, List<CandidateSelectionTag>> tagsByPlace = new LinkedHashMap<>(
-                taggedPlaceSelection.tagsByPlace()
-        );
-        final Set<Place> recommendedCandidatePlaceSet = toPlaceSet(recommendedCandidatePlaces);
+        appendGeneralFallback(taggedPlaceSelection, searchedPlaces, placeCondition);
+        return taggedPlaceSelection;
+    }
 
-        if (selectedByTag.containsKey(CandidateSelectionTag.GENERAL)) {
-            return new TaggedPlaceSelection(recommendedCandidatePlaces, selectedByTag, tagsByPlace);
+    private void appendGeneralFallback(
+            final TaggedPlaceSelection taggedPlaceSelection,
+            final List<Place> searchedPlaces,
+            final Predicate<Place> placeCondition
+    ) {
+        final Map<CandidateSelectionTag, Place> selectedByTag = taggedPlaceSelection.selectedByTag();
+        if (hasGeneralSelection(selectedByTag)) {
+            return;
         }
+
+        final List<Place> recommendedCandidatePlaces = taggedPlaceSelection.recommendedCandidatePlaces();
+        final Set<Place> recommendedCandidatePlaceSet = toPlaceSet(recommendedCandidatePlaces);
+        final Map<Place, List<CandidateSelectionTag>> tagsByPlace = taggedPlaceSelection.tagsByPlace();
 
         for (Place place : searchedPlaces) {
             if (recommendedCandidatePlaceSet.contains(place) || !placeCondition.test(place)) {
                 continue;
             }
             recommendedCandidatePlaces.add(place);
-            recommendedCandidatePlaceSet.add(place);
             selectedByTag.put(CandidateSelectionTag.GENERAL, place);
             tagsByPlace.put(place, List.of(CandidateSelectionTag.GENERAL));
-            break;
+            return;
         }
+    }
 
-        return new TaggedPlaceSelection(recommendedCandidatePlaces, selectedByTag, tagsByPlace);
+    private boolean hasGeneralSelection(final Map<CandidateSelectionTag, Place> selectedByTag) {
+        return selectedByTag.containsKey(CandidateSelectionTag.GENERAL);
     }
 
     private TaggedPlaceSelection selectTaggedPlaces(

--- a/backend/src/main/java/com/f12/moitz/domain/recommendation/candidate/CandidatePlaceSearchPolicy.java
+++ b/backend/src/main/java/com/f12/moitz/domain/recommendation/candidate/CandidatePlaceSearchPolicy.java
@@ -18,40 +18,18 @@ public class CandidatePlaceSearchPolicy {
             final Predicate<Place> placeCondition,
             final int limit
     ) {
-        final TaggedPlaceSelection taggedPlaceSelection = selectTaggedPlaces(
+        final TaggedPlaceSelection taggedPlaceSelection = selectCurrentPlaces(
                 candidateSelection,
                 searchedPlaces,
                 placeCondition
         );
-        final List<Place> recommendedCandidatePlaces = new ArrayList<>(taggedPlaceSelection.recommendedCandidatePlaces());
-        final Map<Place, List<CandidateSelectionTag>> tagsByPlace = new LinkedHashMap<>(
-                taggedPlaceSelection.tagsByPlace()
-        );
-        final Set<Place> recommendedCandidatePlaceSet = toPlaceSet(recommendedCandidatePlaces);
-        final Set<CandidateSelectionTag> selectedTags = toTagSet(tagsByPlace);
 
-        for (Place place : searchedPlaces) {
-            if (recommendedCandidatePlaces.size() >= limit) {
-                break;
-            }
-            if (selectedTags.contains(CandidateSelectionTag.GENERAL)) {
-                break;
-            }
-            if (recommendedCandidatePlaceSet.contains(place) || !placeCondition.test(place)) {
-                continue;
-            }
-            recommendedCandidatePlaces.add(place);
-            recommendedCandidatePlaceSet.add(place);
-            tagsByPlace.put(place, List.of(CandidateSelectionTag.GENERAL));
-            selectedTags.add(CandidateSelectionTag.GENERAL);
-        }
-
-        final List<Place> limitedRecommendedCandidatePlaces = recommendedCandidatePlaces.stream()
+        final List<Place> limitedRecommendedCandidatePlaces = taggedPlaceSelection.recommendedCandidatePlaces().stream()
                 .limit(limit)
                 .toList();
         return new RecommendedCandidates(
                 limitedRecommendedCandidatePlaces,
-                tagsByPlace
+                taggedPlaceSelection.tagsByPlace()
         );
     }
 
@@ -61,7 +39,7 @@ public class CandidatePlaceSearchPolicy {
             final Predicate<Place> placeCondition,
             final int limit
     ) {
-        final Map<CandidateSelectionTag, Place> selectedByTag = selectTaggedPlaces(
+        final Map<CandidateSelectionTag, Place> selectedByTag = selectCurrentPlaces(
                 candidateSelection,
                 searchedPlaces,
                 placeCondition
@@ -105,6 +83,43 @@ public class CandidatePlaceSearchPolicy {
                 .toList();
     }
 
+    private TaggedPlaceSelection selectCurrentPlaces(
+            final CandidateSelection candidateSelection,
+            final List<Place> searchedPlaces,
+            final Predicate<Place> placeCondition
+    ) {
+        final TaggedPlaceSelection taggedPlaceSelection = selectTaggedPlaces(
+                candidateSelection,
+                searchedPlaces,
+                placeCondition
+        );
+        final List<Place> recommendedCandidatePlaces = new ArrayList<>(taggedPlaceSelection.recommendedCandidatePlaces());
+        final Map<CandidateSelectionTag, Place> selectedByTag = new LinkedHashMap<>(
+                taggedPlaceSelection.selectedByTag()
+        );
+        final Map<Place, List<CandidateSelectionTag>> tagsByPlace = new LinkedHashMap<>(
+                taggedPlaceSelection.tagsByPlace()
+        );
+        final Set<Place> recommendedCandidatePlaceSet = toPlaceSet(recommendedCandidatePlaces);
+
+        if (selectedByTag.containsKey(CandidateSelectionTag.GENERAL)) {
+            return new TaggedPlaceSelection(recommendedCandidatePlaces, selectedByTag, tagsByPlace);
+        }
+
+        for (Place place : searchedPlaces) {
+            if (recommendedCandidatePlaceSet.contains(place) || !placeCondition.test(place)) {
+                continue;
+            }
+            recommendedCandidatePlaces.add(place);
+            recommendedCandidatePlaceSet.add(place);
+            selectedByTag.put(CandidateSelectionTag.GENERAL, place);
+            tagsByPlace.put(place, List.of(CandidateSelectionTag.GENERAL));
+            break;
+        }
+
+        return new TaggedPlaceSelection(recommendedCandidatePlaces, selectedByTag, tagsByPlace);
+    }
+
     private TaggedPlaceSelection selectTaggedPlaces(
             final CandidateSelection candidateSelection,
             final List<Place> searchedPlaces,
@@ -141,14 +156,6 @@ public class CandidatePlaceSearchPolicy {
 
     private Set<Place> toPlaceSet(final List<Place> places) {
         return new HashSet<>(places);
-    }
-
-    private Set<CandidateSelectionTag> toTagSet(final Map<Place, List<CandidateSelectionTag>> tagsByPlace) {
-        final Set<CandidateSelectionTag> tags = new HashSet<>();
-        tagsByPlace.values().stream()
-                .flatMap(List::stream)
-                .forEach(tags::add);
-        return tags;
     }
 
     private record TaggedPlaceSelection(

--- a/backend/src/main/java/com/f12/moitz/domain/recommendation/candidate/CandidatePlaceSearchPolicy.java
+++ b/backend/src/main/java/com/f12/moitz/domain/recommendation/candidate/CandidatePlaceSearchPolicy.java
@@ -5,10 +5,8 @@ import com.f12.moitz.domain.recommendation.RecommendedCandidates;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -26,13 +24,17 @@ public class CandidatePlaceSearchPolicy {
                 placeCondition
         );
         final List<Place> recommendedCandidatePlaces = new ArrayList<>(taggedPlaceSelection.recommendedCandidatePlaces());
-        final Set<Place> recommendedCandidatePlaceSet = toPlaceSet(recommendedCandidatePlaces);
         final Map<Place, List<CandidateSelectionTag>> tagsByPlace = new LinkedHashMap<>(
                 taggedPlaceSelection.tagsByPlace()
         );
+        final Set<Place> recommendedCandidatePlaceSet = toPlaceSet(recommendedCandidatePlaces);
+        final Set<CandidateSelectionTag> selectedTags = toTagSet(tagsByPlace);
 
         for (Place place : searchedPlaces) {
             if (recommendedCandidatePlaces.size() >= limit) {
+                break;
+            }
+            if (selectedTags.contains(CandidateSelectionTag.GENERAL)) {
                 break;
             }
             if (recommendedCandidatePlaceSet.contains(place) || !placeCondition.test(place)) {
@@ -41,6 +43,7 @@ public class CandidatePlaceSearchPolicy {
             recommendedCandidatePlaces.add(place);
             recommendedCandidatePlaceSet.add(place);
             tagsByPlace.put(place, List.of(CandidateSelectionTag.GENERAL));
+            selectedTags.add(CandidateSelectionTag.GENERAL);
         }
 
         final List<Place> limitedRecommendedCandidatePlaces = recommendedCandidatePlaces.stream()
@@ -48,11 +51,7 @@ public class CandidatePlaceSearchPolicy {
                 .toList();
         return new RecommendedCandidates(
                 limitedRecommendedCandidatePlaces,
-                normalizeTransferTags(
-                        candidateSelection,
-                        limitedRecommendedCandidatePlaces,
-                        tagsByPlace
-                )
+                tagsByPlace
         );
     }
 
@@ -84,7 +83,7 @@ public class CandidatePlaceSearchPolicy {
                     .ifPresent(place -> nextSearchPlaces.putIfAbsent(place, place));
         }
 
-        if (!nextSearchPlaces.isEmpty()) {
+        if (!nextSearchPlaces.isEmpty() || selectedByTag.containsKey(CandidateSelectionTag.GENERAL)) {
             return nextSearchPlaces.values().stream()
                     .limit(limit)
                     .toList();
@@ -114,7 +113,7 @@ public class CandidatePlaceSearchPolicy {
         final Set<Place> searchedPlaceSet = toPlaceSet(searchedPlaces);
         final Set<Place> selectedPlaceSet = new HashSet<>();
         final Map<CandidateSelectionTag, Place> selectedByTag = new LinkedHashMap<>();
-        final Map<Place, Set<CandidateSelectionTag>> tagsByPlace = new LinkedHashMap<>();
+        final Map<Place, List<CandidateSelectionTag>> tagsByPlace = new LinkedHashMap<>();
 
         for (CandidateSelectionTag tag : CandidateSelectionTag.orderedValues()) {
             final List<RouteCandidate> tagCandidates = candidateSelection.getCandidatesByTag(tag);
@@ -124,12 +123,11 @@ public class CandidatePlaceSearchPolicy {
                     continue;
                 }
                 if (selectedPlaceSet.contains(place)) {
-                    addTag(tagsByPlace, place, tag);
                     continue;
                 }
                 selectedByTag.put(tag, place);
                 selectedPlaceSet.add(place);
-                addTag(tagsByPlace, place, tag);
+                tagsByPlace.put(place, List.of(tag));
                 break;
             }
         }
@@ -137,106 +135,20 @@ public class CandidatePlaceSearchPolicy {
         return new TaggedPlaceSelection(
                 new ArrayList<>(selectedByTag.values()),
                 selectedByTag,
-                copyTagsByPlace(tagsByPlace)
+                tagsByPlace
         );
-    }
-
-    private void addTag(
-            final Map<Place, Set<CandidateSelectionTag>> tagsByPlace,
-            final Place place,
-            final CandidateSelectionTag tag
-    ) {
-        final Set<CandidateSelectionTag> tags = tagsByPlace.computeIfAbsent(place, ignored -> new LinkedHashSet<>());
-        if (tag != CandidateSelectionTag.GENERAL) {
-            tags.add(tag);
-            return;
-        }
-
-        if (tags.isEmpty()) {
-            tags.add(CandidateSelectionTag.GENERAL);
-        }
-    }
-
-    private Map<Place, List<CandidateSelectionTag>> copyTagsByPlace(
-            final Map<Place, Set<CandidateSelectionTag>> tagsByPlace
-    ) {
-        final Map<Place, List<CandidateSelectionTag>> copiedTagsByPlace = new LinkedHashMap<>();
-        tagsByPlace.forEach((place, tags) -> copiedTagsByPlace.put(place, List.copyOf(tags)));
-        return copiedTagsByPlace;
     }
 
     private Set<Place> toPlaceSet(final List<Place> places) {
         return new HashSet<>(places);
     }
 
-    private Map<Place, List<CandidateSelectionTag>> normalizeTransferTags(
-            final CandidateSelection candidateSelection,
-            final List<Place> recommendedCandidatePlaces,
-            final Map<Place, List<CandidateSelectionTag>> tagsByPlace
-    ) {
-        final Map<Place, RouteCandidate> candidatesByPlace = candidatesByPlace(candidateSelection);
-        final List<TransferBurden> transferBurdens = recommendedCandidatePlaces.stream()
-                .map(candidatesByPlace::get)
-                .filter(Objects::nonNull)
-                .map(RouteCandidate::calculateTransferBurden)
-                .toList();
-
-        if (transferBurdens.isEmpty()) {
-            return tagsByPlace;
-        }
-
-        final TransferBurden bestTransferBurden = transferBurdens.stream()
-                .min(TransferBurden::compareTo)
-                .orElseThrow();
-        final Set<Place> transferCandidatePlaces = transferCandidatePlaces(candidateSelection);
-        final Map<Place, List<CandidateSelectionTag>> normalizedTagsByPlace = new LinkedHashMap<>();
-        recommendedCandidatePlaces.forEach(place -> normalizedTagsByPlace.put(
-                place,
-                normalizeTransferTag(place, tagsByPlace, candidatesByPlace, transferCandidatePlaces, bestTransferBurden)
-        ));
-        return normalizedTagsByPlace;
-    }
-
-    private Set<Place> transferCandidatePlaces(final CandidateSelection candidateSelection) {
-        final Set<Place> transferCandidatePlaces = new HashSet<>();
-        candidateSelection.getCandidatesByTag(CandidateSelectionTag.TRANSFER)
-                .forEach(candidate -> transferCandidatePlaces.add(candidate.getPlace()));
-        return transferCandidatePlaces;
-    }
-
-    private Map<Place, RouteCandidate> candidatesByPlace(final CandidateSelection candidateSelection) {
-        final Map<Place, RouteCandidate> candidatesByPlace = new LinkedHashMap<>();
-        candidateSelection.getSearchCandidates()
-                .forEach(candidate -> candidatesByPlace.putIfAbsent(candidate.getPlace(), candidate));
-        CandidateSelectionTag.orderedValues()
-                .forEach(tag -> candidateSelection.getCandidatesByTag(tag)
-                        .forEach(candidate -> candidatesByPlace.putIfAbsent(candidate.getPlace(), candidate)));
-        return candidatesByPlace;
-    }
-
-    private List<CandidateSelectionTag> normalizeTransferTag(
-            final Place place,
-            final Map<Place, List<CandidateSelectionTag>> tagsByPlace,
-            final Map<Place, RouteCandidate> candidatesByPlace,
-            final Set<Place> transferCandidatePlaces,
-            final TransferBurden bestTransferBurden
-    ) {
-        final List<CandidateSelectionTag> tags = tagsByPlace.getOrDefault(place, List.of(CandidateSelectionTag.GENERAL));
-        final RouteCandidate candidate = candidatesByPlace.get(place);
-        final boolean isBestTransfer = candidate != null
-                && candidate.calculateTransferBurden().compareTo(bestTransferBurden) == 0;
-
-        if (isBestTransfer && transferCandidatePlaces.contains(place)) {
-            if (tags.contains(CandidateSelectionTag.TRANSFER)) {
-                return tags;
-            }
-            final List<CandidateSelectionTag> tagsWithTransfer = new ArrayList<>(tags);
-            tagsWithTransfer.add(CandidateSelectionTag.TRANSFER);
-            return tagsWithTransfer;
-        }
-        return tags.stream()
-                .filter(tag -> tag != CandidateSelectionTag.TRANSFER)
-                .toList();
+    private Set<CandidateSelectionTag> toTagSet(final Map<Place, List<CandidateSelectionTag>> tagsByPlace) {
+        final Set<CandidateSelectionTag> tags = new HashSet<>();
+        tagsByPlace.values().stream()
+                .flatMap(List::stream)
+                .forEach(tags::add);
+        return tags;
     }
 
     private record TaggedPlaceSelection(

--- a/backend/src/main/java/com/f12/moitz/domain/recommendation/candidate/CandidateSelectionTag.java
+++ b/backend/src/main/java/com/f12/moitz/domain/recommendation/candidate/CandidateSelectionTag.java
@@ -7,11 +7,11 @@ import java.util.Objects;
 
 public enum CandidateSelectionTag {
 
-    FAIRNESS(1, "#공평", "모든 참여자의 이동 시간이 최대한 비슷한 기준"),
-    MAX_BURDEN_RELIEF(2, "#최대부담완화", "가장 오래 이동하는 사람의 부담을 줄이는 기준"),
-    EFFICIENCY(3, "#평균최소", "전체 참여자의 평균 이동 시간이 짧은 기준"),
+    FAIRNESS(1, "#가장공평", "모든 참여자의 이동 시간이 가장 공평한 기준"),
+    MAX_BURDEN_RELIEF(2, "#최대짧은", "가장 오래 이동하는 사람의 이동 시간이 짧은 기준"),
+    EFFICIENCY(3, "#최소평균", "전체 참여자의 평균 이동 시간이 짧은 기준"),
     TRANSFER(4, "#최소환승", "환승 부담이 적은 기준"),
-    GENERAL(5, "#종합추천", "이동 시간, 환승, 균형을 종합한 기준");
+    GENERAL(5, "#적당한", "이동 시간, 환승, 균형이 적당한 기준");
 
     private final int priority;
     private final String hashtag;
@@ -46,20 +46,16 @@ public enum CandidateSelectionTag {
             return List.of(GENERAL);
         }
 
-        final List<CandidateSelectionTag> resolvedTags = tags.stream()
+        return tags.stream()
                 .filter(Objects::nonNull)
-                .distinct()
-                .toList();
-
-        if (resolvedTags.isEmpty()) {
-            return List.of(GENERAL);
-        }
-        if (resolvedTags.size() == 1) {
-            return resolvedTags;
-        }
-        return resolvedTags.stream()
                 .filter(tag -> tag != GENERAL)
-                .toList();
+                .min(Comparator.comparingInt(CandidateSelectionTag::getPriority))
+                .map(List::of)
+                .orElseGet(() -> tags.stream()
+                        .filter(Objects::nonNull)
+                        .findFirst()
+                        .map(List::of)
+                        .orElse(List.of(GENERAL)));
     }
 
 }

--- a/backend/src/main/java/com/f12/moitz/infrastructure/adapter/place/PlaceRecommenderParallelAdapter.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/adapter/place/PlaceRecommenderParallelAdapter.java
@@ -1,6 +1,7 @@
 package com.f12.moitz.infrastructure.adapter.place;
 
 import com.f12.moitz.application.port.place.PlaceRecommender;
+import com.f12.moitz.application.port.place.PlaceRecommendationCriteria;
 import com.f12.moitz.common.error.exception.ExternalApiErrorCode;
 import com.f12.moitz.common.error.exception.ExternalApiException;
 import com.f12.moitz.domain.recommendation.RecommendedPlaces;
@@ -27,48 +28,49 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class PlaceRecommenderParallelAdapter implements PlaceRecommender {
 
-    private static final int PLACE_RECOMMENDATION_COUNT = 5;
-
     private final KakaoMapAsyncClient kakaoMapAsyncClient;
     private final KakaoPlaceMapper kakaoPlaceMapper;
 
     @Override
     public Map<Place, RecommendedPlaces> recommendPlaces(
             final List<Place> targetPlaces,
-            final List<RecommendCondition> requirements
+            final PlaceRecommendationCriteria criteria
     ) {
-        return recommendPlacesAsync(targetPlaces, requirements)
+        return recommendPlacesAsync(targetPlaces, criteria)
                 .block();
     }
 
     private Mono<Map<Place, RecommendedPlaces>> recommendPlacesAsync(
             final List<Place> targetPlaces,
-            final List<RecommendCondition> requirements
+            final PlaceRecommendationCriteria criteria
     ) {
-        return searchPlacesWithRequirementAsync(targetPlaces, requirements)
-                .map(this::buildRecommendedPlaces);
+        return searchPlacesWithRequirementAsync(targetPlaces, criteria)
+                .map(searchResults -> buildRecommendedPlaces(searchResults, criteria.limitPerCondition()));
     }
 
     private Map<Place, RecommendedPlaces> buildRecommendedPlaces(
-            final Map<Place, Map<RecommendCondition, List<KakaoApiResponse>>> searchResults
+            final Map<Place, Map<RecommendCondition, List<KakaoApiResponse>>> searchResults,
+            final int limitPerCondition
     ) {
         return searchResults.entrySet().stream()
                 .collect(Collectors.toMap(
                         Entry::getKey,
                         entry -> new RecommendedPlaces(
-                                buildCategoryMap(entry.getValue())
+                                buildCategoryMap(entry.getValue(), limitPerCondition)
                         )
                 ));
     }
 
     private Map<RecommendCondition, List<RecommendedPlace>> buildCategoryMap(
-            final Map<RecommendCondition, List<KakaoApiResponse>> categoryResponses
+            final Map<RecommendCondition, List<KakaoApiResponse>> categoryResponses,
+            final int limitPerCondition
     ) {
         return categoryResponses.entrySet().stream()
                 .collect(Collectors.toMap(
                         Entry::getKey,
                         entry -> entry.getValue().stream()
                                 .flatMap(resp -> resp.documents().stream())
+                                .limit(limitPerCondition)
                                 .map(kakaoPlaceMapper::toRecommendedPlace)
                                 .toList()
                 ));
@@ -76,10 +78,10 @@ public class PlaceRecommenderParallelAdapter implements PlaceRecommender {
 
     private Mono<Map<Place, Map<RecommendCondition, List<KakaoApiResponse>>>> searchPlacesWithRequirementAsync(
             final List<Place> targetPlaces,
-            final List<RecommendCondition> requirements
+            final PlaceRecommendationCriteria criteria
     ) {
         return Flux.fromIterable(targetPlaces)
-                .flatMap(place -> searchRequirementsForPlaceAsync(place, requirements)
+                .flatMap(place -> searchRequirementsForPlaceAsync(place, criteria)
                         .map(requirementMap -> Map.entry(place, requirementMap))
                 )
                 .collectMap(Map.Entry::getKey, Map.Entry::getValue);
@@ -87,16 +89,17 @@ public class PlaceRecommenderParallelAdapter implements PlaceRecommender {
 
     private Mono<Map<RecommendCondition, List<KakaoApiResponse>>> searchRequirementsForPlaceAsync(
             final Place place,
-            final List<RecommendCondition> requirements
+            final PlaceRecommendationCriteria criteria
     ) {
-        return Flux.fromIterable(requirements)
-                .flatMap(condition -> searchKeywordsForConditionAsync(condition, place))
+        return Flux.fromIterable(criteria.conditions())
+                .flatMap(condition -> searchKeywordsForConditionAsync(condition, place, criteria.limitPerCondition()))
                 .collectMap(Map.Entry::getKey, Map.Entry::getValue, HashMap::new);
     }
 
     private Mono<Map.Entry<RecommendCondition, List<KakaoApiResponse>>> searchKeywordsForConditionAsync(
             final RecommendCondition condition,
-            final Place place
+            final Place place,
+            final int limitPerCondition
     ) {
         return Flux.fromIterable(condition.getKeywords())
                 .flatMap(keyword -> kakaoMapAsyncClient.searchPlacesByAsync(
@@ -106,7 +109,7 @@ public class PlaceRecommenderParallelAdapter implements PlaceRecommender {
                                 place.getPoint().getX(),
                                 place.getPoint().getY(),
                                 800,
-                                PLACE_RECOMMENDATION_COUNT
+                                limitPerCondition
                         )
                 )
                 .retry(2)

--- a/backend/src/main/java/com/f12/moitz/infrastructure/adapter/place/PlaceRecommenderParallelAdapter.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/adapter/place/PlaceRecommenderParallelAdapter.java
@@ -80,6 +80,7 @@ public class PlaceRecommenderParallelAdapter implements PlaceRecommender {
             final List<KakaoApiResponse> responses,
             final int limitPerCondition
     ) {
+        // interleaveDocuments는 documentsByKeyword를 index 기준 라운드로빈으로 순회하며, limitPerCondition 도달 또는 hasNextDocument=false까지 짧은 리스트를 건너뛰고 긴 리스트로 채운다.
         final List<List<DocumentResponse>> documentsByKeyword = responses.stream()
                 .map(this::getDocuments)
                 .toList();

--- a/backend/src/main/java/com/f12/moitz/infrastructure/adapter/place/PlaceRecommenderParallelAdapter.java
+++ b/backend/src/main/java/com/f12/moitz/infrastructure/adapter/place/PlaceRecommenderParallelAdapter.java
@@ -10,8 +10,10 @@ import com.f12.moitz.domain.recommendation.RecommendCondition;
 import com.f12.moitz.domain.recommendation.RecommendedPlace;
 import com.f12.moitz.infrastructure.client.kakao.KakaoMapAsyncClient;
 import com.f12.moitz.infrastructure.client.kakao.dto.KakaoApiResponse;
+import com.f12.moitz.infrastructure.client.kakao.dto.DocumentResponse;
 import com.f12.moitz.infrastructure.client.kakao.dto.SearchPlacesLimitQuantityRequest;
 import com.f12.moitz.infrastructure.utils.KakaoPlaceMapper;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,12 +70,47 @@ public class PlaceRecommenderParallelAdapter implements PlaceRecommender {
         return categoryResponses.entrySet().stream()
                 .collect(Collectors.toMap(
                         Entry::getKey,
-                        entry -> entry.getValue().stream()
-                                .flatMap(resp -> resp.documents().stream())
-                                .limit(limitPerCondition)
+                        entry -> interleaveDocuments(entry.getValue(), limitPerCondition).stream()
                                 .map(kakaoPlaceMapper::toRecommendedPlace)
                                 .toList()
                 ));
+    }
+
+    private List<DocumentResponse> interleaveDocuments(
+            final List<KakaoApiResponse> responses,
+            final int limitPerCondition
+    ) {
+        final List<List<DocumentResponse>> documentsByKeyword = responses.stream()
+                .map(this::getDocuments)
+                .toList();
+        final List<DocumentResponse> interleavedDocuments = new ArrayList<>();
+
+        for (int index = 0; interleavedDocuments.size() < limitPerCondition; index++) {
+            boolean hasNextDocument = false;
+
+            for (List<DocumentResponse> documents : documentsByKeyword) {
+                if (index < documents.size()) {
+                    interleavedDocuments.add(documents.get(index));
+                    hasNextDocument = true;
+                }
+                if (interleavedDocuments.size() == limitPerCondition) {
+                    return interleavedDocuments;
+                }
+            }
+
+            if (!hasNextDocument) {
+                return interleavedDocuments;
+            }
+        }
+
+        return interleavedDocuments;
+    }
+
+    private List<DocumentResponse> getDocuments(final KakaoApiResponse response) {
+        if (response.documents() == null) {
+            return List.of();
+        }
+        return response.documents();
     }
 
     private Mono<Map<Place, Map<RecommendCondition, List<KakaoApiResponse>>>> searchPlacesWithRequirementAsync(
@@ -102,7 +139,7 @@ public class PlaceRecommenderParallelAdapter implements PlaceRecommender {
             final int limitPerCondition
     ) {
         return Flux.fromIterable(condition.getKeywords())
-                .flatMap(keyword -> kakaoMapAsyncClient.searchPlacesByAsync(
+                .flatMapSequential(keyword -> kakaoMapAsyncClient.searchPlacesByAsync(
                         new SearchPlacesLimitQuantityRequest(
                                 keyword,
                                 place.getName(),

--- a/backend/src/test/java/com/f12/moitz/application/RecommendationPlaceSearchServiceTest.java
+++ b/backend/src/test/java/com/f12/moitz/application/RecommendationPlaceSearchServiceTest.java
@@ -1,10 +1,12 @@
 package com.f12.moitz.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import com.f12.moitz.application.port.place.PlaceRecommendationCriteria;
 import com.f12.moitz.application.port.place.PlaceRecommender;
 import com.f12.moitz.application.recommendation.RecommendationPlaceSearchResult;
 import com.f12.moitz.application.recommendation.RecommendationPlaceSearchService;
@@ -65,13 +67,15 @@ class RecommendationPlaceSearchServiceTest {
                 seolleung, createRecommendedPlaces("선릉 카페"),
                 samsung, createRecommendedPlaces("삼성 카페")
         );
-        given(placeRecommender.recommendPlaces(anyList(), anyList())).willReturn(recommendedPlaces);
+        given(placeRecommender.recommendPlaces(anyList(), any(PlaceRecommendationCriteria.class)))
+                .willReturn(recommendedPlaces);
 
         final RecommendationPlaceSearchResult result = service.search(
                 candidateSelection,
                 List.of(RecommendCondition.CAFE),
                 candidateRoutes,
                 5,
+                6,
                 2
         );
 
@@ -81,9 +85,13 @@ class RecommendationPlaceSearchServiceTest {
         assertThat(result.getRecommendedPlaceCount()).isEqualTo(2);
         assertThat(result.getRecommendedCandidates().getPlaces()).containsExactly(seolleung, samsung);
 
-        final ArgumentCaptor<List<Place>> captor = ArgumentCaptor.forClass(List.class);
-        verify(placeRecommender).recommendPlaces(captor.capture(), anyList());
-        assertThat(captor.getValue()).containsExactly(seolleung, samsung);
+        final ArgumentCaptor<List<Place>> placesCaptor = ArgumentCaptor.forClass(List.class);
+        final ArgumentCaptor<PlaceRecommendationCriteria> criteriaCaptor =
+                ArgumentCaptor.forClass(PlaceRecommendationCriteria.class);
+        verify(placeRecommender).recommendPlaces(placesCaptor.capture(), criteriaCaptor.capture());
+        assertThat(placesCaptor.getValue()).containsExactly(seolleung, samsung);
+        assertThat(criteriaCaptor.getValue().conditions()).containsExactly(RecommendCondition.CAFE);
+        assertThat(criteriaCaptor.getValue().limitPerCondition()).isEqualTo(6);
     }
 
     @Test
@@ -110,7 +118,7 @@ class RecommendationPlaceSearchServiceTest {
                 seolleung, seolleungCandidate.getRoutes(),
                 samsung, samsungCandidate.getRoutes()
         );
-        given(placeRecommender.recommendPlaces(anyList(), anyList())).willReturn(Map.of(
+        given(placeRecommender.recommendPlaces(anyList(), any(PlaceRecommendationCriteria.class))).willReturn(Map.of(
                 seolleung, createRecommendedPlaces("선릉 카페"),
                 samsung, new RecommendedPlaces(Map.of())
         ));
@@ -120,6 +128,7 @@ class RecommendationPlaceSearchServiceTest {
                 List.of(RecommendCondition.CAFE),
                 candidateRoutes,
                 2,
+                6,
                 2
         );
 

--- a/backend/src/test/java/com/f12/moitz/application/RecommendationServiceTest.java
+++ b/backend/src/test/java/com/f12/moitz/application/RecommendationServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.f12.moitz.application.dto.recommendation.RecommendationRequest;
+import com.f12.moitz.application.port.place.PlaceRecommendationCriteria;
 import com.f12.moitz.application.port.place.PlaceRecommender;
 import com.f12.moitz.application.subway.SubwayRouteService;
 import com.f12.moitz.application.recommendation.RecommendationPlaceSearchService;
@@ -121,7 +122,7 @@ class RecommendationServiceTest {
                         )
                 )
         );
-        given(placeRecommender.recommendPlaces(anyList(), anyList()))
+        given(placeRecommender.recommendPlaces(anyList(), any(PlaceRecommendationCriteria.class)))
                 .willReturn(mockRecommendedPlaces);
 
         List<Route> pairwiseRoutes = List.of(
@@ -169,6 +170,12 @@ class RecommendationServiceTest {
                         List.of("FAIRNESS"),
                         List.of("MAX_BURDEN_RELIEF")
                 );
+
+        ArgumentCaptor<PlaceRecommendationCriteria> criteriaCaptor =
+                ArgumentCaptor.forClass(PlaceRecommendationCriteria.class);
+        verify(placeRecommender).recommendPlaces(anyList(), criteriaCaptor.capture());
+        assertThat(criteriaCaptor.getValue().conditions()).containsExactly(RecommendCondition.CAFE);
+        assertThat(criteriaCaptor.getValue().limitPerCondition()).isEqualTo(6);
     }
 
     @Test
@@ -190,7 +197,7 @@ class RecommendationServiceTest {
                 new Route(List.of(new Path(gangnam, seolleung, TravelMethod.SUBWAY, 10 * 60, SubwayLine.fromTitle("2호선")))),
                 new Route(List.of(new Path(yeoksam, seolleung, TravelMethod.SUBWAY, 5 * 60, SubwayLine.fromTitle("2호선"))))
         ));
-        given(placeRecommender.recommendPlaces(anyList(), anyList())).willReturn(Map.of(
+        given(placeRecommender.recommendPlaces(anyList(), any(PlaceRecommendationCriteria.class))).willReturn(Map.of(
                 seolleung, new RecommendedPlaces(Map.of())
         ));
 

--- a/backend/src/test/java/com/f12/moitz/application/RecommendationServiceTest.java
+++ b/backend/src/test/java/com/f12/moitz/application/RecommendationServiceTest.java
@@ -204,7 +204,7 @@ class RecommendationServiceTest {
         assertThatThrownBy(() -> recommendationService.recommendLocation(request))
                 .isInstanceOfSatisfying(BadRequestException.class,
                         exception -> assertThat(exception.getErrorCode())
-                                .isEqualTo(GeneralErrorCode.RECOMMENDATION_NOT_FOUND));
+                                .isEqualTo(GeneralErrorCode.RECOMMENDATION_RESULT_EMPTY));
     }
 
     @Test

--- a/backend/src/test/java/com/f12/moitz/application/RecommendationServiceTest.java
+++ b/backend/src/test/java/com/f12/moitz/application/RecommendationServiceTest.java
@@ -166,8 +166,8 @@ class RecommendationServiceTest {
                         .toList())
                 .toList())
                 .containsExactly(
-                        List.of("FAIRNESS", "EFFICIENCY", "TRANSFER"),
-                        List.of("MAX_BURDEN_RELIEF", "EFFICIENCY", "TRANSFER")
+                        List.of("FAIRNESS"),
+                        List.of("MAX_BURDEN_RELIEF")
                 );
     }
 

--- a/backend/src/test/java/com/f12/moitz/application/dto/recommendation/LocationResponseTest.java
+++ b/backend/src/test/java/com/f12/moitz/application/dto/recommendation/LocationResponseTest.java
@@ -41,6 +41,29 @@ class LocationResponseTest {
     }
 
     @Test
+    void serialize_WithTagInfoAndLocationInfo_ListInput() throws Exception {
+        final LocationResponse response = new LocationResponse(
+                1L,
+                1,
+                37.0,
+                127.0,
+                "서울역",
+                20,
+                false,
+                List.of("EFFICIENCY"),
+                "#최소평균",
+                "서울역은 전체 참여자의 평균 이동 시간이 짧은 기준을 반영해 추천된 만남 장소입니다.",
+                Map.of(),
+                List.of()
+        );
+
+        final JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(response));
+
+        assertThat(json.get("tag_info").asText()).isEqualTo("전체 참여자의 평균 이동 시간이 짧은 기준");
+        assertThat(json.get("location_info").asText()).isEqualTo(response.reason());
+    }
+
+    @Test
     void create_ThrowsExceptionWhenTagsHaveMultipleValues() {
         assertThatThrownBy(() -> new LocationResponse(
                 1L,
@@ -79,6 +102,29 @@ class LocationResponseTest {
                 .isInstanceOfSatisfying(BadRequestException.class, exception -> {
                     assertThat(exception.getErrorCode()).isEqualTo(GeneralErrorCode.INPUT_INVALID_RECOMMENDATION_TAG);
                     assertThat(exception).hasMessageContaining("UNKNOWN");
+                    assertThat(exception).hasCauseInstanceOf(IllegalArgumentException.class);
+                });
+    }
+
+    @Test
+    void serialize_WithTagInfoAndLocationInfo_InvalidTagThrows() {
+        assertThatThrownBy(() -> new LocationResponse(
+                1L,
+                1,
+                37.0,
+                127.0,
+                "서울역",
+                20,
+                false,
+                List.of("INVALID_TAG"),
+                "#알수없음",
+                "서울역 추천 이유입니다.",
+                Map.of(),
+                List.of()
+        ))
+                .isInstanceOfSatisfying(BadRequestException.class, exception -> {
+                    assertThat(exception.getErrorCode()).isEqualTo(GeneralErrorCode.INPUT_INVALID_RECOMMENDATION_TAG);
+                    assertThat(exception).hasMessageContaining("INVALID_TAG");
                     assertThat(exception).hasCauseInstanceOf(IllegalArgumentException.class);
                 });
     }

--- a/backend/src/test/java/com/f12/moitz/application/dto/recommendation/LocationResponseTest.java
+++ b/backend/src/test/java/com/f12/moitz/application/dto/recommendation/LocationResponseTest.java
@@ -64,7 +64,7 @@ class LocationResponseTest {
     }
 
     @Test
-    void create_ThrowsExceptionWhenTagsHaveMultipleValues() {
+    void create_ThrowsBadRequestExceptionWhenTagsHaveMultipleValues() {
         assertThatThrownBy(() -> new LocationResponse(
                 1L,
                 1,
@@ -79,8 +79,32 @@ class LocationResponseTest {
                 Map.of(),
                 List.of()
         ))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("추천 태그는 하나만 가질 수 있습니다.");
+                .isInstanceOfSatisfying(BadRequestException.class, exception ->
+                        assertThat(exception.getErrorCode())
+                                .isEqualTo(GeneralErrorCode.INPUT_INVALID_RECOMMENDATION_TAG)
+                );
+    }
+
+    @Test
+    void create_ThrowsBadRequestExceptionWhenTagsAreEmpty() {
+        assertThatThrownBy(() -> new LocationResponse(
+                1L,
+                1,
+                37.0,
+                127.0,
+                "서울역",
+                20,
+                false,
+                List.of(),
+                "#최소환승",
+                "서울역은 환승 부담이 적은 기준을 반영해 추천된 만남 장소입니다.",
+                Map.of(),
+                List.of()
+        ))
+                .isInstanceOfSatisfying(BadRequestException.class, exception ->
+                        assertThat(exception.getErrorCode())
+                                .isEqualTo(GeneralErrorCode.INPUT_INVALID_RECOMMENDATION_TAG)
+                );
     }
 
     @Test

--- a/backend/src/test/java/com/f12/moitz/application/dto/recommendation/LocationResponseTest.java
+++ b/backend/src/test/java/com/f12/moitz/application/dto/recommendation/LocationResponseTest.java
@@ -1,6 +1,7 @@
 package com.f12.moitz.application.dto.recommendation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,6 +36,26 @@ class LocationResponseTest {
         assertThat(json.get("location_info").asText()).isEqualTo(response.reason());
         assertThat(json.has("tagInfo")).isFalse();
         assertThat(json.has("locationInfo")).isFalse();
+    }
+
+    @Test
+    void create_ThrowsExceptionWhenTagsHaveMultipleValues() {
+        assertThatThrownBy(() -> new LocationResponse(
+                1L,
+                1,
+                37.0,
+                127.0,
+                "서울역",
+                20,
+                false,
+                List.of("TRANSFER", "EFFICIENCY"),
+                "#최소환승",
+                "서울역은 환승 부담이 적은 기준을 반영해 추천된 만남 장소입니다.",
+                Map.of(),
+                List.of()
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("추천 태그는 하나만 가질 수 있습니다.");
     }
 
 }

--- a/backend/src/test/java/com/f12/moitz/application/dto/recommendation/LocationResponseTest.java
+++ b/backend/src/test/java/com/f12/moitz/application/dto/recommendation/LocationResponseTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.f12.moitz.common.error.exception.BadRequestException;
+import com.f12.moitz.common.error.exception.GeneralErrorCode;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -56,6 +58,29 @@ class LocationResponseTest {
         ))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("추천 태그는 하나만 가질 수 있습니다.");
+    }
+
+    @Test
+    void create_ThrowsBadRequestExceptionWhenTagIsUnknown() {
+        assertThatThrownBy(() -> new LocationResponse(
+                1L,
+                1,
+                37.0,
+                127.0,
+                "서울역",
+                20,
+                false,
+                "UNKNOWN",
+                "#알수없음",
+                "서울역 추천 이유입니다.",
+                Map.of(),
+                List.of()
+        ))
+                .isInstanceOfSatisfying(BadRequestException.class, exception -> {
+                    assertThat(exception.getErrorCode()).isEqualTo(GeneralErrorCode.INPUT_INVALID_RECOMMENDATION_TAG);
+                    assertThat(exception).hasMessageContaining("UNKNOWN");
+                    assertThat(exception).hasCauseInstanceOf(IllegalArgumentException.class);
+                });
     }
 
 }

--- a/backend/src/test/java/com/f12/moitz/application/dto/recommendation/LocationResponseTest.java
+++ b/backend/src/test/java/com/f12/moitz/application/dto/recommendation/LocationResponseTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.f12.moitz.common.error.exception.BadRequestException;
 import com.f12.moitz.common.error.exception.GeneralErrorCode;
+import com.f12.moitz.domain.recommendation.candidate.CandidateSelectionTag;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ class LocationResponseTest {
 
         final JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(response));
 
-        assertThat(json.get("tag_info").asText()).isEqualTo("환승 부담이 적은 기준");
+        assertThat(json.get("tag_info").asText()).isEqualTo(CandidateSelectionTag.TRANSFER.getDescription());
         assertThat(json.get("location_info").asText()).isEqualTo(response.reason());
         assertThat(json.has("tagInfo")).isFalse();
         assertThat(json.has("locationInfo")).isFalse();
@@ -59,7 +60,7 @@ class LocationResponseTest {
 
         final JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(response));
 
-        assertThat(json.get("tag_info").asText()).isEqualTo("전체 참여자의 평균 이동 시간이 짧은 기준");
+        assertThat(json.get("tag_info").asText()).isEqualTo(CandidateSelectionTag.EFFICIENCY.getDescription());
         assertThat(json.get("location_info").asText()).isEqualTo(response.reason());
     }
 

--- a/backend/src/test/java/com/f12/moitz/application/dto/recommendation/LocationResponseTest.java
+++ b/backend/src/test/java/com/f12/moitz/application/dto/recommendation/LocationResponseTest.java
@@ -1,0 +1,40 @@
+package com.f12.moitz.application.dto.recommendation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class LocationResponseTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void serialize_WithTagInfoAndLocationInfo() throws Exception {
+        final LocationResponse response = new LocationResponse(
+                1L,
+                1,
+                37.0,
+                127.0,
+                "서울역",
+                20,
+                false,
+                "TRANSFER",
+                "#최소환승",
+                "서울역은 환승 부담이 적은 기준을 반영해 추천된 만남 장소입니다.",
+                Map.of(),
+                List.of()
+        );
+
+        final JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(response));
+
+        assertThat(json.get("tag_info").asText()).isEqualTo("환승 부담이 적은 기준");
+        assertThat(json.get("location_info").asText()).isEqualTo(response.reason());
+        assertThat(json.has("tagInfo")).isFalse();
+        assertThat(json.has("locationInfo")).isFalse();
+    }
+
+}

--- a/backend/src/test/java/com/f12/moitz/application/port/place/PlaceRecommendationCriteriaTest.java
+++ b/backend/src/test/java/com/f12/moitz/application/port/place/PlaceRecommendationCriteriaTest.java
@@ -1,0 +1,43 @@
+package com.f12.moitz.application.port.place;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.f12.moitz.common.error.exception.BadRequestException;
+import com.f12.moitz.common.error.exception.GeneralErrorCode;
+import com.f12.moitz.domain.recommendation.RecommendCondition;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PlaceRecommendationCriteriaTest {
+
+    @Test
+    void create_ThrowsBadRequestExceptionWhenConditionsAreEmpty() {
+        assertThatThrownBy(() -> new PlaceRecommendationCriteria(List.of(), 6))
+                .isInstanceOfSatisfying(BadRequestException.class, exception ->
+                        assertThat(exception.getErrorCode())
+                                .isEqualTo(GeneralErrorCode.INPUT_INVALID_RECOMMEND_CONDITION)
+                );
+    }
+
+    @Test
+    void create_ThrowsBadRequestExceptionWhenConditionsContainNull() {
+        assertThatThrownBy(() -> new PlaceRecommendationCriteria(
+                Arrays.asList(RecommendCondition.CAFE, null),
+                6
+        ))
+                .isInstanceOfSatisfying(BadRequestException.class, exception ->
+                        assertThat(exception.getErrorCode())
+                                .isEqualTo(GeneralErrorCode.INPUT_INVALID_RECOMMEND_CONDITION)
+                );
+    }
+
+    @Test
+    void create_ThrowsIllegalArgumentExceptionWhenLimitPerConditionIsInvalid() {
+        assertThatThrownBy(() -> new PlaceRecommendationCriteria(List.of(RecommendCondition.CAFE), 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("추천 장소 개수는 1개 이상이어야 합니다.");
+    }
+
+}

--- a/backend/src/test/java/com/f12/moitz/application/recommendation/utils/RecommendationResponseMapperTest.java
+++ b/backend/src/test/java/com/f12/moitz/application/recommendation/utils/RecommendationResponseMapperTest.java
@@ -61,6 +61,63 @@ class RecommendationResponseMapperTest {
         assertThat(location.locationInfo()).isEqualTo(location.reason());
     }
 
+    @Test
+    @DisplayName("저장된 태그가 모두 일반 태그이면 일반 태그 기준으로 응답한다")
+    void toResponse_WhenAllTagsAreGeneral_ReturnsGeneralNormalized() {
+        final RecommendationResultResponse response = mapper.toResponse(createResult(
+                createCandidate(List.of(CandidateSelectionTag.GENERAL))
+        ));
+
+        assertGeneralLocation(response.locations().getFirst());
+    }
+
+    @Test
+    @DisplayName("저장된 태그가 비어있거나 null이면 일반 태그 기준으로 응답한다")
+    void toResponse_WhenSelectionTagsEmptyOrNull_HandleGracefully() {
+        final RecommendationResultResponse emptyTagsResponse = mapper.toResponse(createResult(
+                createCandidate(List.of())
+        ));
+        final RecommendationResultResponse nullTagsResponse = mapper.toResponse(createResult(
+                createCandidate(null)
+        ));
+
+        assertGeneralLocation(emptyTagsResponse.locations().getFirst());
+        assertGeneralLocation(nullTagsResponse.locations().getFirst());
+    }
+
+    private Result createResult(final Candidate candidate) {
+        final Place startPlace = new Place("강남역", new Point(127.027, 37.497));
+        return new Result(
+                List.of(RecommendCondition.CAFE),
+                List.of(startPlace),
+                new Recommendation(List.of(candidate))
+        );
+    }
+
+    private Candidate createCandidate(final List<CandidateSelectionTag> tags) {
+        final Place startPlace = new Place("강남역", new Point(127.027, 37.497));
+        final Place candidatePlace = new Place("선릉역", new Point(127.048, 37.504));
+        return new Candidate(
+                candidatePlace,
+                new Routes(List.of(createRoute(startPlace, candidatePlace))),
+                new Courses(List.of(new Course(List.of(startPlace.getPoint(), candidatePlace.getPoint())))),
+                createRecommendedPlaces(),
+                tags,
+                "#저장된태그",
+                "저장된 추천 이유입니다.",
+                0
+        );
+    }
+
+    private void assertGeneralLocation(final LocationResponse location) {
+        assertThat(location.tags()).containsExactly(CandidateSelectionTag.GENERAL.name());
+        assertThat(location.tagInfo()).isEqualTo(CandidateSelectionTag.GENERAL.getDescription());
+        assertThat(location.description()).isEqualTo(CandidateSelectionTag.GENERAL.getHashtag());
+        assertThat(location.reason())
+                .isEqualTo("선릉역은 이동 시간, 환승, 균형이 적당한 기준을 반영해 추천된 만남 장소입니다.");
+        assertThat(location.locationInfo()).isEqualTo(location.reason());
+    }
+
     private Route createRoute(final Place startPlace, final Place candidatePlace) {
         return new Route(List.of(new Path(
                 startPlace,

--- a/backend/src/test/java/com/f12/moitz/application/recommendation/utils/RecommendationResponseMapperTest.java
+++ b/backend/src/test/java/com/f12/moitz/application/recommendation/utils/RecommendationResponseMapperTest.java
@@ -1,0 +1,88 @@
+package com.f12.moitz.application.recommendation.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.f12.moitz.application.dto.recommendation.LocationResponse;
+import com.f12.moitz.application.dto.recommendation.RecommendationResultResponse;
+import com.f12.moitz.domain.place.Place;
+import com.f12.moitz.domain.place.Point;
+import com.f12.moitz.domain.recommendation.Candidate;
+import com.f12.moitz.domain.recommendation.RecommendCondition;
+import com.f12.moitz.domain.recommendation.Recommendation;
+import com.f12.moitz.domain.recommendation.RecommendedPlace;
+import com.f12.moitz.domain.recommendation.RecommendedPlaces;
+import com.f12.moitz.domain.recommendation.Result;
+import com.f12.moitz.domain.recommendation.candidate.CandidateSelectionTag;
+import com.f12.moitz.domain.route.Course;
+import com.f12.moitz.domain.route.Courses;
+import com.f12.moitz.domain.route.Path;
+import com.f12.moitz.domain.route.Route;
+import com.f12.moitz.domain.route.Routes;
+import com.f12.moitz.domain.route.TravelMethod;
+import com.f12.moitz.domain.subway.SubwayLine;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RecommendationResponseMapperTest {
+
+    private final RecommendationResponseMapper mapper = new RecommendationResponseMapper();
+
+    @Test
+    @DisplayName("저장된 추천 이유가 오래된 다중 태그 기준이어도 정규화된 태그 기준으로 응답한다")
+    void toResponse_RecomputesReasonWithNormalizedTags() {
+        final Place startPlace = new Place("강남역", new Point(127.027, 37.497));
+        final Place candidatePlace = new Place("선릉역", new Point(127.048, 37.504));
+        final Candidate candidate = new Candidate(
+                candidatePlace,
+                new Routes(List.of(createRoute(startPlace, candidatePlace))),
+                new Courses(List.of(new Course(List.of(startPlace.getPoint(), candidatePlace.getPoint())))),
+                createRecommendedPlaces(),
+                List.of(CandidateSelectionTag.FAIRNESS, CandidateSelectionTag.TRANSFER),
+                "#가장공평 #최소환승",
+                "선릉역은 모든 참여자의 이동 시간이 가장 공평한 기준, 환승 부담이 적은 기준을 반영해 추천된 만남 장소입니다.",
+                0
+        );
+        final Result result = new Result(
+                List.of(RecommendCondition.CAFE),
+                List.of(startPlace),
+                new Recommendation(List.of(candidate))
+        );
+
+        final RecommendationResultResponse response = mapper.toResponse(result);
+
+        final LocationResponse location = response.locations().getFirst();
+        assertThat(location.tags()).containsExactly(CandidateSelectionTag.FAIRNESS.name());
+        assertThat(location.tagInfo()).isEqualTo("모든 참여자의 이동 시간이 가장 공평한 기준");
+        assertThat(location.description()).isEqualTo("#가장공평");
+        assertThat(location.reason())
+                .isEqualTo("선릉역은 모든 참여자의 이동 시간이 가장 공평한 기준을 반영해 추천된 만남 장소입니다.");
+        assertThat(location.locationInfo()).isEqualTo(location.reason());
+    }
+
+    private Route createRoute(final Place startPlace, final Place candidatePlace) {
+        return new Route(List.of(new Path(
+                startPlace,
+                candidatePlace,
+                TravelMethod.SUBWAY,
+                10 * 60,
+                SubwayLine.fromTitle("2호선")
+        )));
+    }
+
+    private RecommendedPlaces createRecommendedPlaces() {
+        return new RecommendedPlaces(Map.of(
+                RecommendCondition.CAFE,
+                List.of(new RecommendedPlace(
+                        "스타벅스 선릉점",
+                        new Point(127.048, 37.504),
+                        "카페",
+                        5,
+                        "url",
+                        "imageUrl"
+                ))
+        ));
+    }
+
+}

--- a/backend/src/test/java/com/f12/moitz/domain/recommendation/CandidateTest.java
+++ b/backend/src/test/java/com/f12/moitz/domain/recommendation/CandidateTest.java
@@ -141,8 +141,8 @@ class CandidateTest {
     }
 
     @Test
-    @DisplayName("후보는 여러 추천 태그를 가질 수 있다")
-    void createWithMultipleTags() {
+    @DisplayName("후보에 여러 추천 태그가 들어오면 우선순위가 가장 높은 단일 태그만 가진다")
+    void createWithMultipleTags_NormalizesToSingleTag() {
         final Place startPlace = new Place("잠실역", new Point(127.0, 37.0));
         final Place endPlace = new Place("강남역", new Point(127.2, 37.2));
         final Route route = new Route(List.of(new Path(
@@ -172,7 +172,7 @@ class CandidateTest {
         );
 
         assertThat(candidate.getTags())
-                .containsExactly(CandidateSelectionTag.FAIRNESS, CandidateSelectionTag.EFFICIENCY);
+                .containsExactly(CandidateSelectionTag.FAIRNESS);
         assertThat(candidate.getTag()).isEqualTo(CandidateSelectionTag.FAIRNESS);
     }
 
@@ -211,7 +211,7 @@ class CandidateTest {
     }
 
     @Test
-    @DisplayName("저장 문서에 태그 정보가 없거나 비어있으면 종합 추천 태그로 보정한다")
+    @DisplayName("저장 문서에 태그 정보가 없거나 비어있으면 적당한 태그로 보정한다")
     void getTags_UsesGeneralWhenTagsAndLegacyTagAreMissing() throws Exception {
         final var constructor = Candidate.class.getDeclaredConstructor();
         constructor.setAccessible(true);
@@ -238,7 +238,7 @@ class CandidateTest {
     }
 
     @Test
-    @DisplayName("종합 추천 태그는 다른 태그가 없는 경우에만 조회한다")
+    @DisplayName("적당한 태그는 다른 태그가 없는 경우에만 조회한다")
     void getTags_RemovesGeneralWhenOtherTagsExist() throws Exception {
         final var constructor = Candidate.class.getDeclaredConstructor();
         constructor.setAccessible(true);

--- a/backend/src/test/java/com/f12/moitz/domain/recommendation/RecommendationReasonTest.java
+++ b/backend/src/test/java/com/f12/moitz/domain/recommendation/RecommendationReasonTest.java
@@ -11,30 +11,30 @@ import org.junit.jupiter.api.Test;
 class RecommendationReasonTest {
 
     @Test
-    @DisplayName("추천 태그를 해시태그 설명과 문장 이유로 변환한다")
+    @DisplayName("여러 추천 태그가 들어오면 우선순위가 가장 높은 단일 태그로 추천 이유를 생성한다")
     void fromSelectionTags_CreatesReasonFromTags() {
         final RecommendationReason reason = RecommendationReason.fromSelectionTags(
                 "서울역",
                 List.of(CandidateSelectionTag.TRANSFER, CandidateSelectionTag.EFFICIENCY)
         );
 
-        assertThat(reason.description()).isEqualTo("#최소환승 #평균최소");
+        assertThat(reason.description()).isEqualTo("#최소평균");
         assertThat(reason.reason())
-                .isEqualTo("서울역은 환승 부담이 적은 기준, 전체 참여자의 평균 이동 시간이 짧은 기준을 반영해 추천된 만남 장소입니다.");
+                .isEqualTo("서울역은 전체 참여자의 평균 이동 시간이 짧은 기준을 반영해 추천된 만남 장소입니다.");
     }
 
     @Test
-    @DisplayName("추천 태그가 없으면 종합 추천 이유를 생성한다")
+    @DisplayName("추천 태그가 없으면 적당한 추천 이유를 생성한다")
     void fromSelectionTags_UsesGeneralReasonWhenTagsAreMissing() {
         final RecommendationReason reason = RecommendationReason.fromSelectionTags("시청역", List.of());
 
-        assertThat(reason.description()).isEqualTo("#종합추천");
+        assertThat(reason.description()).isEqualTo("#적당한");
         assertThat(reason.reason())
-                .isEqualTo("시청역은 이동 시간, 환승, 균형을 종합한 기준을 반영해 추천된 만남 장소입니다.");
+                .isEqualTo("시청역은 이동 시간, 환승, 균형이 적당한 기준을 반영해 추천된 만남 장소입니다.");
     }
 
     @Test
-    @DisplayName("종합 추천 태그는 다른 추천 태그가 없는 경우에만 이유에 포함한다")
+    @DisplayName("적당한 태그는 다른 추천 태그가 없는 경우에만 이유에 포함한다")
     void fromSelectionTags_RemovesGeneralReasonWhenOtherTagsExist() {
         final RecommendationReason reason = RecommendationReason.fromSelectionTags(
                 "서울역",

--- a/backend/src/test/java/com/f12/moitz/domain/recommendation/RecommendationTest.java
+++ b/backend/src/test/java/com/f12/moitz/domain/recommendation/RecommendationTest.java
@@ -131,7 +131,7 @@ class RecommendationTest {
     }
 
     @Test
-    @DisplayName("후보지들을 태그 순서 우선으로 정렬한다")
+    @DisplayName("후보지들을 공평성 점수 우선으로 정렬한다")
     void sortCandidates() {
         // Given
         final Candidate generalCandidate = createCandidate(1200, 600, CandidateSelectionTag.GENERAL);
@@ -143,9 +143,22 @@ class RecommendationTest {
         final Recommendation recommendation = new Recommendation(candidates);
 
         // Then
-        assertThat(recommendation.get(0)).isEqualTo(fairnessCandidate);
+        assertThat(recommendation.get(0)).isEqualTo(generalCandidate);
         assertThat(recommendation.get(1)).isEqualTo(transferCandidate);
-        assertThat(recommendation.get(2)).isEqualTo(generalCandidate);
+        assertThat(recommendation.get(2)).isEqualTo(fairnessCandidate);
+    }
+
+    @Test
+    @DisplayName("공평성 점수가 같으면 태그 순서로 정렬한다")
+    void sortCandidates_UsesTagPriorityWhenFairnessScoreIsSame() {
+        final Candidate generalCandidate = createCandidate(1200, 600, CandidateSelectionTag.GENERAL);
+        final Candidate fairnessCandidate = createCandidate(1200, 600, CandidateSelectionTag.FAIRNESS);
+        final List<Candidate> candidates = List.of(generalCandidate, fairnessCandidate);
+
+        final Recommendation recommendation = new Recommendation(candidates);
+
+        assertThat(recommendation.get(0)).isEqualTo(fairnessCandidate);
+        assertThat(recommendation.get(1)).isEqualTo(generalCandidate);
     }
 
     @Test

--- a/backend/src/test/java/com/f12/moitz/domain/recommendation/RecommendationTest.java
+++ b/backend/src/test/java/com/f12/moitz/domain/recommendation/RecommendationTest.java
@@ -46,7 +46,7 @@ class RecommendationTest {
                 createRecommendedCandidateTravels(startPlace, recommendedPlace),
                 createRecommendedCandidates(
                         List.of(recommendedPlace),
-                        Map.of(recommendedPlace, List.of(CandidateSelectionTag.FAIRNESS))
+                        Map.of(recommendedPlace, CandidateSelectionTag.FAIRNESS)
                 )
         );
 
@@ -71,7 +71,7 @@ class RecommendationTest {
                 createRecommendedCandidateTravels(startPlace, recommendedPlace),
                 createRecommendedCandidates(
                         List.of(recommendedPlace),
-                        Map.of(recommendedPlace, List.of(CandidateSelectionTag.FAIRNESS))
+                        Map.of(recommendedPlace, CandidateSelectionTag.FAIRNESS)
                 )
         ))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -220,7 +220,7 @@ class RecommendationTest {
 
     private RecommendedCandidates createRecommendedCandidates(
             final List<Place> recommendedPlaces,
-            final Map<Place, List<CandidateSelectionTag>> tagsByPlace
+            final Map<Place, CandidateSelectionTag> tagsByPlace
     ) {
         return new RecommendedCandidates(recommendedPlaces, tagsByPlace);
     }

--- a/backend/src/test/java/com/f12/moitz/domain/recommendation/RecommendedCandidatesTest.java
+++ b/backend/src/test/java/com/f12/moitz/domain/recommendation/RecommendedCandidatesTest.java
@@ -8,6 +8,7 @@ import com.f12.moitz.domain.recommendation.candidate.CandidateSelectionTag;
 import com.f12.moitz.domain.place.Place;
 import com.f12.moitz.domain.place.Point;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
@@ -17,7 +18,7 @@ class RecommendedCandidatesTest {
 
     @Test
     @DisplayName("추천 후보 장소 기준으로 단일 태그를 정규화한다")
-    void constructor_NormalizesTagsByRecommendedCandidatePlaces() {
+    void constructor_NormalizesTagByRecommendedCandidatePlaces() {
         final Place seolleung = place("선릉역");
         final Place samsung = place("삼성역");
         final Place gangnam = place("강남역");
@@ -25,41 +26,40 @@ class RecommendedCandidatesTest {
         final RecommendedCandidates recommendedCandidates = new RecommendedCandidates(
                 List.of(seolleung, samsung),
                 Map.of(
-                        seolleung, List.of(CandidateSelectionTag.FAIRNESS, CandidateSelectionTag.GENERAL),
-                        gangnam, List.of(CandidateSelectionTag.TRANSFER)
+                        seolleung, CandidateSelectionTag.FAIRNESS,
+                        gangnam, CandidateSelectionTag.TRANSFER
                 )
         );
 
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(recommendedCandidates.getPlaces())
                     .containsExactly(seolleung, samsung);
-            softAssertions.assertThat(recommendedCandidates.getTags(seolleung))
-                    .containsExactly(CandidateSelectionTag.FAIRNESS);
-            softAssertions.assertThat(recommendedCandidates.getTags(samsung))
-                    .containsExactly(CandidateSelectionTag.GENERAL);
+            softAssertions.assertThat(recommendedCandidates.getTag(seolleung))
+                    .isEqualTo(CandidateSelectionTag.FAIRNESS);
+            softAssertions.assertThat(recommendedCandidates.getTag(samsung))
+                    .isEqualTo(CandidateSelectionTag.GENERAL);
             softAssertions.assertThat(recommendedCandidates.size()).isEqualTo(2);
             softAssertions.assertThat(recommendedCandidates.isEmpty()).isFalse();
         });
     }
 
     @Test
-    @DisplayName("추천 후보 태그가 비어있거나 null만 있으면 적당한 추천 태그로 보정한다")
-    void constructor_UsesGeneralWhenTagsAreEmptyOrOnlyNull() {
+    @DisplayName("추천 후보 태그가 없거나 null이면 적당한 추천 태그로 보정한다")
+    void constructor_UsesGeneralWhenTagsAreMissingOrNull() {
         final Place seolleung = place("선릉역");
         final Place samsung = place("삼성역");
+        final Map<Place, CandidateSelectionTag> tagsByPlace = new LinkedHashMap<>();
+        tagsByPlace.put(samsung, null);
 
         final RecommendedCandidates recommendedCandidates = new RecommendedCandidates(
                 List.of(seolleung, samsung),
-                Map.of(
-                        seolleung, List.of(),
-                        samsung, Arrays.asList(null, null)
-                )
+                tagsByPlace
         );
 
-        assertThat(recommendedCandidates.getTags(seolleung))
-                .containsExactly(CandidateSelectionTag.GENERAL);
-        assertThat(recommendedCandidates.getTags(samsung))
-                .containsExactly(CandidateSelectionTag.GENERAL);
+        assertThat(recommendedCandidates.getTag(seolleung))
+                .isEqualTo(CandidateSelectionTag.GENERAL);
+        assertThat(recommendedCandidates.getTag(samsung))
+                .isEqualTo(CandidateSelectionTag.GENERAL);
     }
 
     @Test
@@ -70,33 +70,33 @@ class RecommendedCandidatesTest {
         final RecommendedCandidates recommendedCandidates = new RecommendedCandidates(
                 List.of(seolleung, samsung),
                 Map.of(
-                        seolleung, List.of(CandidateSelectionTag.FAIRNESS),
-                        samsung, List.of(CandidateSelectionTag.EFFICIENCY, CandidateSelectionTag.GENERAL)
+                        seolleung, CandidateSelectionTag.FAIRNESS,
+                        samsung, CandidateSelectionTag.EFFICIENCY
                 )
         );
 
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(recommendedCandidates.getPlaceNames())
                     .containsExactly("선릉역", "삼성역");
-            softAssertions.assertThat(recommendedCandidates.getTagsByPlaceName())
-                    .containsEntry("선릉역", List.of(CandidateSelectionTag.FAIRNESS))
-                    .containsEntry("삼성역", List.of(CandidateSelectionTag.EFFICIENCY))
+            softAssertions.assertThat(recommendedCandidates.getTagByPlaceName())
+                    .containsEntry("선릉역", CandidateSelectionTag.FAIRNESS)
+                    .containsEntry("삼성역", CandidateSelectionTag.EFFICIENCY)
                     .hasSize(2);
         });
     }
 
     @Test
     @DisplayName("추천 후보 이름별 태그는 외부에서 변경할 수 없다")
-    void getTagsByPlaceName_ReturnsUnmodifiableMap() {
+    void getTagByPlaceName_ReturnsUnmodifiableMap() {
         final Place seolleung = place("선릉역");
         final RecommendedCandidates recommendedCandidates = new RecommendedCandidates(
                 List.of(seolleung),
-                Map.of(seolleung, List.of(CandidateSelectionTag.FAIRNESS))
+                Map.of(seolleung, CandidateSelectionTag.FAIRNESS)
         );
 
-        assertThatThrownBy(() -> recommendedCandidates.getTagsByPlaceName().put(
+        assertThatThrownBy(() -> recommendedCandidates.getTagByPlaceName().put(
                 "삼성역",
-                List.of(CandidateSelectionTag.EFFICIENCY)
+                CandidateSelectionTag.EFFICIENCY
         ))
                 .isInstanceOf(UnsupportedOperationException.class);
     }
@@ -125,7 +125,7 @@ class RecommendedCandidatesTest {
         final Place seolleung = place("선릉역");
         final RecommendedCandidates recommendedCandidates = new RecommendedCandidates(
                 List.of(seolleung),
-                Map.of(seolleung, List.of(CandidateSelectionTag.FAIRNESS))
+                Map.of(seolleung, CandidateSelectionTag.FAIRNESS)
         );
 
         assertThatThrownBy(() -> recommendedCandidates.getPlaces().add(place("삼성역")))
@@ -140,8 +140,8 @@ class RecommendedCandidatesTest {
         final RecommendedCandidates recommendedCandidates = new RecommendedCandidates(
                 List.of(seolleung, samsung),
                 Map.of(
-                        seolleung, List.of(CandidateSelectionTag.FAIRNESS),
-                        samsung, List.of(CandidateSelectionTag.EFFICIENCY)
+                        seolleung, CandidateSelectionTag.FAIRNESS,
+                        samsung, CandidateSelectionTag.EFFICIENCY
                 )
         );
 
@@ -178,19 +178,19 @@ class RecommendedCandidatesTest {
 
     @Test
     @DisplayName("추천 후보가 아닌 장소의 태그는 조회할 수 없다")
-    void getTags_ThrowsExceptionWhenPlaceIsNotRecommendedCandidate() {
+    void getTag_ThrowsExceptionWhenPlaceIsNotRecommendedCandidate() {
         final Place seolleung = place("선릉역");
         final Place samsung = place("삼성역");
         final RecommendedCandidates recommendedCandidates = new RecommendedCandidates(
                 List.of(seolleung),
-                Map.of(seolleung, List.of(CandidateSelectionTag.FAIRNESS))
+                Map.of(seolleung, CandidateSelectionTag.FAIRNESS)
         );
 
         assertSoftly(softAssertions -> {
-            softAssertions.assertThatThrownBy(() -> recommendedCandidates.getTags(null))
+            softAssertions.assertThatThrownBy(() -> recommendedCandidates.getTag(null))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("추천 후보 장소는 null일 수 없습니다.");
-            softAssertions.assertThatThrownBy(() -> recommendedCandidates.getTags(samsung))
+            softAssertions.assertThatThrownBy(() -> recommendedCandidates.getTag(samsung))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("추천 후보 태그가 누락되었습니다. 추천 지역: 삼성역");
         });

--- a/backend/src/test/java/com/f12/moitz/domain/recommendation/RecommendedCandidatesTest.java
+++ b/backend/src/test/java/com/f12/moitz/domain/recommendation/RecommendedCandidatesTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 class RecommendedCandidatesTest {
 
     @Test
-    @DisplayName("추천 후보 장소 기준으로 태그를 정규화한다")
+    @DisplayName("추천 후보 장소 기준으로 단일 태그를 정규화한다")
     void constructor_NormalizesTagsByRecommendedCandidatePlaces() {
         final Place seolleung = place("선릉역");
         final Place samsung = place("삼성역");
@@ -43,7 +43,7 @@ class RecommendedCandidatesTest {
     }
 
     @Test
-    @DisplayName("추천 후보 태그가 비어있거나 null만 있으면 종합 추천 태그로 보정한다")
+    @DisplayName("추천 후보 태그가 비어있거나 null만 있으면 적당한 추천 태그로 보정한다")
     void constructor_UsesGeneralWhenTagsAreEmptyOrOnlyNull() {
         final Place seolleung = place("선릉역");
         final Place samsung = place("삼성역");
@@ -63,7 +63,7 @@ class RecommendedCandidatesTest {
     }
 
     @Test
-    @DisplayName("추천 후보 이름 목록과 이름별 태그를 조회한다")
+    @DisplayName("추천 후보 이름 목록과 이름별 단일 태그를 조회한다")
     void getPlaceNamesAndTagsByPlaceName() {
         final Place seolleung = place("선릉역");
         final Place samsung = place("삼성역");
@@ -149,17 +149,17 @@ class RecommendedCandidatesTest {
 
         assertThat(result)
                 .containsEntry(seolleung, new RecommendationReason(
-                        "#공평",
-                        "선릉역은 모든 참여자의 이동 시간이 최대한 비슷한 기준을 반영해 추천된 만남 장소입니다."
+                        "#가장공평",
+                        "선릉역은 모든 참여자의 이동 시간이 가장 공평한 기준을 반영해 추천된 만남 장소입니다."
                 ))
                 .containsEntry(samsung, new RecommendationReason(
-                        "#평균최소",
+                        "#최소평균",
                         "삼성역은 전체 참여자의 평균 이동 시간이 짧은 기준을 반영해 추천된 만남 장소입니다."
                 ));
     }
 
     @Test
-    @DisplayName("추천 태그가 없으면 종합 추천 이유를 생성한다")
+    @DisplayName("추천 태그가 없으면 적당한 추천 이유를 생성한다")
     void createReasons_UsesGeneralReasonWhenTagsAreMissing() {
         final Place cityHall = place("시청역");
         final RecommendedCandidates recommendedCandidates = new RecommendedCandidates(
@@ -171,8 +171,8 @@ class RecommendedCandidatesTest {
 
         assertThat(result)
                 .containsEntry(cityHall, new RecommendationReason(
-                        "#종합추천",
-                        "시청역은 이동 시간, 환승, 균형을 종합한 기준을 반영해 추천된 만남 장소입니다."
+                        "#적당한",
+                        "시청역은 이동 시간, 환승, 균형이 적당한 기준을 반영해 추천된 만남 장소입니다."
                 ));
     }
 

--- a/backend/src/test/java/com/f12/moitz/domain/recommendation/candidate/CandidatePlaceSearchPolicyTest.java
+++ b/backend/src/test/java/com/f12/moitz/domain/recommendation/candidate/CandidatePlaceSearchPolicyTest.java
@@ -47,16 +47,16 @@ class CandidatePlaceSearchPolicyTest {
         assertThat(recommendedCandidates.getPlaces())
                 .extracting(Place::getName)
                 .containsExactly("공통후보역", "최장후보역", "평균후보역", "환승후보역", "일반후보역");
-        assertThat(recommendedCandidates.getTags(shared.getPlace()))
-                .containsExactly(CandidateSelectionTag.FAIRNESS);
-        assertThat(recommendedCandidates.getTags(maxBurden.getPlace()))
-                .containsExactly(CandidateSelectionTag.MAX_BURDEN_RELIEF);
-        assertThat(recommendedCandidates.getTags(efficiency.getPlace()))
-                .containsExactly(CandidateSelectionTag.EFFICIENCY);
-        assertThat(recommendedCandidates.getTags(transfer.getPlace()))
-                .containsExactly(CandidateSelectionTag.TRANSFER);
-        assertThat(recommendedCandidates.getTags(general.getPlace()))
-                .containsExactly(CandidateSelectionTag.GENERAL);
+        assertThat(recommendedCandidates.getTag(shared.getPlace()))
+                .isEqualTo(CandidateSelectionTag.FAIRNESS);
+        assertThat(recommendedCandidates.getTag(maxBurden.getPlace()))
+                .isEqualTo(CandidateSelectionTag.MAX_BURDEN_RELIEF);
+        assertThat(recommendedCandidates.getTag(efficiency.getPlace()))
+                .isEqualTo(CandidateSelectionTag.EFFICIENCY);
+        assertThat(recommendedCandidates.getTag(transfer.getPlace()))
+                .isEqualTo(CandidateSelectionTag.TRANSFER);
+        assertThat(recommendedCandidates.getTag(general.getPlace()))
+                .isEqualTo(CandidateSelectionTag.GENERAL);
     }
 
     @Test
@@ -110,8 +110,8 @@ class CandidatePlaceSearchPolicyTest {
 
         assertThat(recommendedCandidates.getPlaces())
                 .containsExactly(first.getPlace());
-        assertThat(recommendedCandidates.getTags(first.getPlace()))
-                .containsExactly(CandidateSelectionTag.GENERAL);
+        assertThat(recommendedCandidates.getTag(first.getPlace()))
+                .isEqualTo(CandidateSelectionTag.GENERAL);
     }
 
     @Test
@@ -140,8 +140,6 @@ class CandidatePlaceSearchPolicyTest {
                 .containsExactly("대체후보역");
         assertThat(recommendedCandidates.getTag(nextFairness.getPlace()))
                 .isEqualTo(CandidateSelectionTag.FAIRNESS);
-        assertThat(recommendedCandidates.getTags(nextFairness.getPlace()))
-                .containsExactly(CandidateSelectionTag.FAIRNESS);
     }
 
     @Test
@@ -173,14 +171,14 @@ class CandidatePlaceSearchPolicyTest {
                 4
         );
 
-        assertThat(recommendedCandidates.getTags(wangsimni.getPlace()))
-                .containsExactly(CandidateSelectionTag.FAIRNESS);
-        assertThat(recommendedCandidates.getTags(oksu.getPlace()))
-                .containsExactly(CandidateSelectionTag.MAX_BURDEN_RELIEF);
-        assertThat(recommendedCandidates.getTags(yaksu.getPlace()))
-                .containsExactly(CandidateSelectionTag.EFFICIENCY);
-        assertThat(recommendedCandidates.getTags(chungmuro.getPlace()))
-                .containsExactly(CandidateSelectionTag.TRANSFER);
+        assertThat(recommendedCandidates.getTag(wangsimni.getPlace()))
+                .isEqualTo(CandidateSelectionTag.FAIRNESS);
+        assertThat(recommendedCandidates.getTag(oksu.getPlace()))
+                .isEqualTo(CandidateSelectionTag.MAX_BURDEN_RELIEF);
+        assertThat(recommendedCandidates.getTag(yaksu.getPlace()))
+                .isEqualTo(CandidateSelectionTag.EFFICIENCY);
+        assertThat(recommendedCandidates.getTag(chungmuro.getPlace()))
+                .isEqualTo(CandidateSelectionTag.TRANSFER);
     }
 
     @Test
@@ -211,12 +209,12 @@ class CandidatePlaceSearchPolicyTest {
                 3
         );
 
-        assertThat(recommendedCandidates.getTags(fairness.getPlace()))
-                .containsExactly(CandidateSelectionTag.FAIRNESS);
-        assertThat(recommendedCandidates.getTags(general.getPlace()))
-                .containsExactly(CandidateSelectionTag.TRANSFER);
-        assertThat(recommendedCandidates.getTags(highTransfer.getPlace()))
-                .containsExactly(CandidateSelectionTag.MAX_BURDEN_RELIEF);
+        assertThat(recommendedCandidates.getTag(fairness.getPlace()))
+                .isEqualTo(CandidateSelectionTag.FAIRNESS);
+        assertThat(recommendedCandidates.getTag(general.getPlace()))
+                .isEqualTo(CandidateSelectionTag.TRANSFER);
+        assertThat(recommendedCandidates.getTag(highTransfer.getPlace()))
+                .isEqualTo(CandidateSelectionTag.MAX_BURDEN_RELIEF);
     }
 
     @Test
@@ -246,10 +244,10 @@ class CandidatePlaceSearchPolicyTest {
                 2
         );
 
-        assertThat(recommendedCandidates.getTags(bestTransfer.getPlace()))
-                .containsExactly(CandidateSelectionTag.FAIRNESS);
-        assertThat(recommendedCandidates.getTags(taggedTransfer.getPlace()))
-                .containsExactly(CandidateSelectionTag.TRANSFER);
+        assertThat(recommendedCandidates.getTag(bestTransfer.getPlace()))
+                .isEqualTo(CandidateSelectionTag.FAIRNESS);
+        assertThat(recommendedCandidates.getTag(taggedTransfer.getPlace()))
+                .isEqualTo(CandidateSelectionTag.TRANSFER);
     }
 
     @Test
@@ -279,10 +277,10 @@ class CandidatePlaceSearchPolicyTest {
                 2
         );
 
-        assertThat(recommendedCandidates.getTags(general.getPlace()))
-                .containsExactly(CandidateSelectionTag.GENERAL);
-        assertThat(recommendedCandidates.getTags(transfer.getPlace()))
-                .containsExactly(CandidateSelectionTag.TRANSFER);
+        assertThat(recommendedCandidates.getTag(general.getPlace()))
+                .isEqualTo(CandidateSelectionTag.GENERAL);
+        assertThat(recommendedCandidates.getTag(transfer.getPlace()))
+                .isEqualTo(CandidateSelectionTag.TRANSFER);
     }
 
     @Test
@@ -428,8 +426,8 @@ class CandidatePlaceSearchPolicyTest {
                 4
         );
 
-        assertThat(recommendedCandidates.getTags(fallbackGeneral.getPlace()))
-                .containsExactly(CandidateSelectionTag.GENERAL);
+        assertThat(recommendedCandidates.getTag(fallbackGeneral.getPlace()))
+                .isEqualTo(CandidateSelectionTag.GENERAL);
         assertThat(nextSearchPlaces)
                 .isEmpty();
     }

--- a/backend/src/test/java/com/f12/moitz/domain/recommendation/candidate/CandidatePlaceSearchPolicyTest.java
+++ b/backend/src/test/java/com/f12/moitz/domain/recommendation/candidate/CandidatePlaceSearchPolicyTest.java
@@ -21,8 +21,8 @@ class CandidatePlaceSearchPolicyTest {
     private final CandidatePlaceSearchPolicy candidatePlaceSearchPolicy = new CandidatePlaceSearchPolicy();
 
     @Test
-    @DisplayName("추천 후보는 장소 기준으로 중복 제거하고 선택된 후보가 속한 태그를 모두 부여한다")
-    void select_AssignsAllMatchedTagsWithoutDuplicatingPlaces() {
+    @DisplayName("추천 후보는 태그별로 하나의 장소를 선택하고 이미 선택된 장소는 다음 태그에서 건너뛴다")
+    void select_AssignsSinglePlacePerTagWithoutDuplicatingPlaces() {
         final RouteCandidate shared = routeCandidate("공통후보역");
         final RouteCandidate maxBurden = routeCandidate("최장후보역");
         final RouteCandidate efficiency = routeCandidate("평균후보역");
@@ -48,7 +48,7 @@ class CandidatePlaceSearchPolicyTest {
                 .extracting(Place::getName)
                 .containsExactly("공통후보역", "최장후보역", "평균후보역", "환승후보역", "일반후보역");
         assertThat(recommendedCandidates.getTags(shared.getPlace()))
-                .containsExactly(CandidateSelectionTag.FAIRNESS, CandidateSelectionTag.EFFICIENCY);
+                .containsExactly(CandidateSelectionTag.FAIRNESS);
         assertThat(recommendedCandidates.getTags(maxBurden.getPlace()))
                 .containsExactly(CandidateSelectionTag.MAX_BURDEN_RELIEF);
         assertThat(recommendedCandidates.getTags(efficiency.getPlace()))
@@ -88,6 +88,33 @@ class CandidatePlaceSearchPolicyTest {
     }
 
     @Test
+    @DisplayName("태그 후보가 없어서 일반 태그로 보충할 때도 일반 태그는 하나의 장소에만 부여한다")
+    void select_AssignsGeneralTagToSingleFallbackCandidateOnly() {
+        final RouteCandidate first = routeCandidate("일반후보1역");
+        final RouteCandidate second = routeCandidate("일반후보2역");
+        final CandidateSelection candidateSelection = new CandidateSelection(
+                List.of(first, second),
+                DispersionPolicy.TIER_4,
+                DispersionPolicy.TIER_4,
+                2,
+                false,
+                Map.of()
+        );
+
+        final RecommendedCandidates recommendedCandidates = candidatePlaceSearchPolicy.select(
+                candidateSelection,
+                candidateSelection.getSearchCandidatePlaces(),
+                ignored -> true,
+                5
+        );
+
+        assertThat(recommendedCandidates.getPlaces())
+                .containsExactly(first.getPlace());
+        assertThat(recommendedCandidates.getTags(first.getPlace()))
+                .containsExactly(CandidateSelectionTag.GENERAL);
+    }
+
+    @Test
     @DisplayName("태그 후보가 조건을 만족하지 못하면 같은 태그의 다음 후보를 선택한다")
     void select_UsesNextCandidateWhenFirstTaggedCandidateDoesNotSatisfyCondition() {
         final RouteCandidate failedFairness = routeCandidate("실패후보역");
@@ -118,8 +145,8 @@ class CandidatePlaceSearchPolicyTest {
     }
 
     @Test
-    @DisplayName("최소 환승 태그는 최종 후보 중 환승 점수가 가장 낮은 후보에만 부여한다")
-    void select_AssignsTransferTagOnlyToBestTransferBurdensAmongFinalPlaces() {
+    @DisplayName("이미 선택된 후보는 최소 환승 태그에 다시 매핑하지 않고 다음 후보를 선택한다")
+    void select_SelectsNextTransferCandidateWhenBestTransferPlaceAlreadyHasAnotherTag() {
         final RouteCandidate wangsimni = routeCandidateWithTransfers("왕십리역", List.of(0, 0, 2, 2));
         final RouteCandidate oksu = routeCandidateWithTransfers("옥수역", List.of(0, 1, 0, 1));
         final RouteCandidate yaksu = routeCandidateWithTransfers("약수역", List.of(1, 1, 0, 1));
@@ -147,18 +174,18 @@ class CandidatePlaceSearchPolicyTest {
         );
 
         assertThat(recommendedCandidates.getTags(wangsimni.getPlace()))
-                .containsExactly(CandidateSelectionTag.FAIRNESS, CandidateSelectionTag.EFFICIENCY);
+                .containsExactly(CandidateSelectionTag.FAIRNESS);
         assertThat(recommendedCandidates.getTags(oksu.getPlace()))
-                .containsExactly(CandidateSelectionTag.MAX_BURDEN_RELIEF, CandidateSelectionTag.TRANSFER);
+                .containsExactly(CandidateSelectionTag.MAX_BURDEN_RELIEF);
         assertThat(recommendedCandidates.getTags(yaksu.getPlace()))
                 .containsExactly(CandidateSelectionTag.EFFICIENCY);
         assertThat(recommendedCandidates.getTags(chungmuro.getPlace()))
-                .containsExactly(CandidateSelectionTag.GENERAL);
+                .containsExactly(CandidateSelectionTag.TRANSFER);
     }
 
     @Test
-    @DisplayName("최종 후보 중 같은 최소 환승 점수인 후보에는 최소 환승 태그를 함께 부여한다")
-    void select_AddsTransferTagToAllBestTransferBurdenPlaces() {
+    @DisplayName("최소 환승 점수가 같은 후보가 있어도 최소 환승 태그는 단일 후보에만 부여한다")
+    void select_AssignsTransferTagToSingleCandidateOnly() {
         final RouteCandidate fairness = routeCandidateWithTransfers("공평후보역", List.of(0, 1));
         final RouteCandidate general = routeCandidateWithTransfers("일반후보역", List.of(0, 1));
         final RouteCandidate highTransfer = routeCandidateWithTransfers("환승많은역", List.of(1, 1));
@@ -185,7 +212,7 @@ class CandidatePlaceSearchPolicyTest {
         );
 
         assertThat(recommendedCandidates.getTags(fairness.getPlace()))
-                .containsExactly(CandidateSelectionTag.FAIRNESS, CandidateSelectionTag.TRANSFER);
+                .containsExactly(CandidateSelectionTag.FAIRNESS);
         assertThat(recommendedCandidates.getTags(general.getPlace()))
                 .containsExactly(CandidateSelectionTag.TRANSFER);
         assertThat(recommendedCandidates.getTags(highTransfer.getPlace()))
@@ -193,8 +220,8 @@ class CandidatePlaceSearchPolicyTest {
     }
 
     @Test
-    @DisplayName("최소 환승 후보가 기존 태그 수집에서 누락되어도 최종 태그 정규화에서 최소 환승 태그를 부여한다")
-    void select_AddsTransferTagWhenBestTransferPlaceWasNotCollectedAsTransferTag() {
+    @DisplayName("최소 환승 태그는 사후 보정으로 다른 태그 후보에 추가하지 않는다")
+    void select_DoesNotAddTransferTagByPostNormalization() {
         final RouteCandidate bestTransfer = routeCandidateWithTransfers("최소환승역", List.of(0, 1));
         final RouteCandidate taggedTransfer = routeCandidateWithTransfers("태그수집환승역", List.of(1, 1));
         final Map<CandidateSelectionTag, List<RouteCandidate>> tagSelections = new LinkedHashMap<>();
@@ -220,9 +247,9 @@ class CandidatePlaceSearchPolicyTest {
         );
 
         assertThat(recommendedCandidates.getTags(bestTransfer.getPlace()))
-                .containsExactly(CandidateSelectionTag.FAIRNESS, CandidateSelectionTag.TRANSFER);
+                .containsExactly(CandidateSelectionTag.FAIRNESS);
         assertThat(recommendedCandidates.getTags(taggedTransfer.getPlace()))
-                .containsExactly(CandidateSelectionTag.GENERAL);
+                .containsExactly(CandidateSelectionTag.TRANSFER);
     }
 
     @Test
@@ -322,8 +349,8 @@ class CandidatePlaceSearchPolicyTest {
     }
 
     @Test
-    @DisplayName("비어있는 태그의 미검색 후보가 더 이상 없으면 일반 후보로 추천 개수를 보충한다")
-    void selectNextSearchPlaces_FillsWithGeneralCandidatesWhenMissingTagCandidatesAreExhausted() {
+    @DisplayName("비어있는 태그의 미검색 후보가 더 이상 없고 일반 태그가 이미 선택되면 추가 조회하지 않는다")
+    void selectNextSearchPlaces_DoesNotFillWithGeneralCandidatesWhenGeneralTagAlreadySelected() {
         final RouteCandidate fairness = routeCandidate("공평후보역");
         final RouteCandidate efficiency = routeCandidate("평균후보역");
         final RouteCandidate general = routeCandidate("일반후보역");
@@ -352,8 +379,7 @@ class CandidatePlaceSearchPolicyTest {
         );
 
         assertThat(nextSearchPlaces)
-                .extracting(Place::getName)
-                .containsExactly("보충후보1역", "보충후보2역");
+                .isEmpty();
     }
 
     private Map<CandidateSelectionTag, List<RouteCandidate>> createTagSelections(

--- a/backend/src/test/java/com/f12/moitz/domain/recommendation/candidate/CandidatePlaceSearchPolicyTest.java
+++ b/backend/src/test/java/com/f12/moitz/domain/recommendation/candidate/CandidatePlaceSearchPolicyTest.java
@@ -382,6 +382,58 @@ class CandidatePlaceSearchPolicyTest {
                 .isEmpty();
     }
 
+    @Test
+    @DisplayName("일반 태그가 보충 후보로 선택된 상태라면 추가 일반 후보를 조회하지 않는다")
+    void selectNextSearchPlaces_DoesNotFillWithGeneralCandidatesWhenFallbackGeneralSelected() {
+        final RouteCandidate fairness = routeCandidate("공평후보역");
+        final RouteCandidate maxBurden = routeCandidate("최장후보역");
+        final RouteCandidate efficiency = routeCandidate("평균후보역");
+        final RouteCandidate transfer = routeCandidate("환승후보역");
+        final RouteCandidate failedGeneral = routeCandidate("실패일반후보역");
+        final RouteCandidate fallbackGeneral = routeCandidate("보충일반후보역");
+        final RouteCandidate nextFiller = routeCandidate("다음보충후보역");
+        final Map<CandidateSelectionTag, List<RouteCandidate>> tagSelections = new LinkedHashMap<>();
+        tagSelections.put(CandidateSelectionTag.FAIRNESS, List.of(fairness));
+        tagSelections.put(CandidateSelectionTag.MAX_BURDEN_RELIEF, List.of(maxBurden));
+        tagSelections.put(CandidateSelectionTag.EFFICIENCY, List.of(efficiency));
+        tagSelections.put(CandidateSelectionTag.TRANSFER, List.of(transfer));
+        tagSelections.put(CandidateSelectionTag.GENERAL, List.of(failedGeneral));
+        final CandidateSelection candidateSelection = new CandidateSelection(
+                List.of(fairness, maxBurden, efficiency, transfer, failedGeneral, fallbackGeneral, nextFiller),
+                DispersionPolicy.TIER_4,
+                DispersionPolicy.TIER_4,
+                7,
+                false,
+                tagSelections
+        );
+        final List<Place> searchedPlaces = List.of(
+                fairness.getPlace(),
+                maxBurden.getPlace(),
+                efficiency.getPlace(),
+                transfer.getPlace(),
+                failedGeneral.getPlace(),
+                fallbackGeneral.getPlace()
+        );
+
+        final RecommendedCandidates recommendedCandidates = candidatePlaceSearchPolicy.select(
+                candidateSelection,
+                searchedPlaces,
+                place -> !place.equals(failedGeneral.getPlace()),
+                5
+        );
+        final List<Place> nextSearchPlaces = candidatePlaceSearchPolicy.selectNextSearchPlaces(
+                candidateSelection,
+                searchedPlaces,
+                place -> !place.equals(failedGeneral.getPlace()),
+                4
+        );
+
+        assertThat(recommendedCandidates.getTags(fallbackGeneral.getPlace()))
+                .containsExactly(CandidateSelectionTag.GENERAL);
+        assertThat(nextSearchPlaces)
+                .isEmpty();
+    }
+
     private Map<CandidateSelectionTag, List<RouteCandidate>> createTagSelections(
             final RouteCandidate shared,
             final RouteCandidate maxBurden,

--- a/backend/src/test/java/com/f12/moitz/domain/recommendation/candidate/CandidatePlaceSearchPolicyTest.java
+++ b/backend/src/test/java/com/f12/moitz/domain/recommendation/candidate/CandidatePlaceSearchPolicyTest.java
@@ -92,11 +92,13 @@ class CandidatePlaceSearchPolicyTest {
     void select_AssignsGeneralTagToSingleFallbackCandidateOnly() {
         final RouteCandidate first = routeCandidate("일반후보1역");
         final RouteCandidate second = routeCandidate("일반후보2역");
+        final int expectedCandidates = 2;
+        final int requestedFallbackCount = 5;
         final CandidateSelection candidateSelection = new CandidateSelection(
                 List.of(first, second),
                 DispersionPolicy.TIER_4,
                 DispersionPolicy.TIER_4,
-                2,
+                expectedCandidates,
                 false,
                 Map.of()
         );
@@ -105,7 +107,7 @@ class CandidatePlaceSearchPolicyTest {
                 candidateSelection,
                 candidateSelection.getSearchCandidatePlaces(),
                 ignored -> true,
-                5
+                requestedFallbackCount
         );
 
         assertThat(recommendedCandidates.getPlaces())

--- a/backend/src/test/java/com/f12/moitz/domain/recommendation/candidate/CandidatePlaceSearchPolicyTest.java
+++ b/backend/src/test/java/com/f12/moitz/domain/recommendation/candidate/CandidatePlaceSearchPolicyTest.java
@@ -286,6 +286,22 @@ class CandidatePlaceSearchPolicyTest {
     }
 
     @Test
+    @DisplayName("일반 태그 후보가 조건을 만족하지 못하면 보충 후보를 일반 태그로 선택한다")
+    void select_AssignsGeneralTagToFallbackCandidateWhenGeneralCandidateFails() {
+        final FallbackGeneralSelectionFixture fixture = createFallbackGeneralSelectionFixture();
+
+        final RecommendedCandidates recommendedCandidates = candidatePlaceSearchPolicy.select(
+                fixture.candidateSelection(),
+                fixture.searchedPlaces(),
+                place -> !place.equals(fixture.failedGeneralPlace()),
+                5
+        );
+
+        assertThat(recommendedCandidates.getTag(fixture.fallbackGeneralPlace()))
+                .isEqualTo(CandidateSelectionTag.GENERAL);
+    }
+
+    @Test
     @DisplayName("다음 장소 검색 대상은 비어있는 태그 후보를 우선하고 이 후보가 남아있다면 일반 후보로 채우지 않는다")
     void selectNextSearchPlaces_PrioritizesMissingTagsWithoutGeneralFillWhenTagCandidatesRemain() {
         final RouteCandidate fairness = routeCandidate("공평후보역");
@@ -385,6 +401,20 @@ class CandidatePlaceSearchPolicyTest {
     @Test
     @DisplayName("일반 태그가 보충 후보로 선택된 상태라면 추가 일반 후보를 조회하지 않는다")
     void selectNextSearchPlaces_DoesNotFillWithGeneralCandidatesWhenFallbackGeneralSelected() {
+        final FallbackGeneralSelectionFixture fixture = createFallbackGeneralSelectionFixture();
+
+        final List<Place> nextSearchPlaces = candidatePlaceSearchPolicy.selectNextSearchPlaces(
+                fixture.candidateSelection(),
+                fixture.searchedPlaces(),
+                place -> !place.equals(fixture.failedGeneralPlace()),
+                4
+        );
+
+        assertThat(nextSearchPlaces)
+                .isEmpty();
+    }
+
+    private FallbackGeneralSelectionFixture createFallbackGeneralSelectionFixture() {
         final RouteCandidate fairness = routeCandidate("공평후보역");
         final RouteCandidate maxBurden = routeCandidate("최장후보역");
         final RouteCandidate efficiency = routeCandidate("평균후보역");
@@ -406,32 +436,28 @@ class CandidatePlaceSearchPolicyTest {
                 false,
                 tagSelections
         );
-        final List<Place> searchedPlaces = List.of(
-                fairness.getPlace(),
-                maxBurden.getPlace(),
-                efficiency.getPlace(),
-                transfer.getPlace(),
+        return new FallbackGeneralSelectionFixture(
+                candidateSelection,
+                List.of(
+                        fairness.getPlace(),
+                        maxBurden.getPlace(),
+                        efficiency.getPlace(),
+                        transfer.getPlace(),
+                        failedGeneral.getPlace(),
+                        fallbackGeneral.getPlace()
+                ),
                 failedGeneral.getPlace(),
                 fallbackGeneral.getPlace()
         );
+    }
 
-        final RecommendedCandidates recommendedCandidates = candidatePlaceSearchPolicy.select(
-                candidateSelection,
-                searchedPlaces,
-                place -> !place.equals(failedGeneral.getPlace()),
-                5
-        );
-        final List<Place> nextSearchPlaces = candidatePlaceSearchPolicy.selectNextSearchPlaces(
-                candidateSelection,
-                searchedPlaces,
-                place -> !place.equals(failedGeneral.getPlace()),
-                4
-        );
+    private record FallbackGeneralSelectionFixture(
+            CandidateSelection candidateSelection,
+            List<Place> searchedPlaces,
+            Place failedGeneralPlace,
+            Place fallbackGeneralPlace
+    ) {
 
-        assertThat(recommendedCandidates.getTag(fallbackGeneral.getPlace()))
-                .isEqualTo(CandidateSelectionTag.GENERAL);
-        assertThat(nextSearchPlaces)
-                .isEmpty();
     }
 
     private Map<CandidateSelectionTag, List<RouteCandidate>> createTagSelections(

--- a/backend/src/test/java/com/f12/moitz/infrastructure/adapter/place/PlaceRecommenderParallelAdapterTest.java
+++ b/backend/src/test/java/com/f12/moitz/infrastructure/adapter/place/PlaceRecommenderParallelAdapterTest.java
@@ -10,6 +10,7 @@ import com.f12.moitz.application.port.place.PlaceRecommendationCriteria;
 import com.f12.moitz.domain.place.Place;
 import com.f12.moitz.domain.place.Point;
 import com.f12.moitz.domain.recommendation.RecommendCondition;
+import com.f12.moitz.domain.recommendation.RecommendedPlace;
 import com.f12.moitz.domain.recommendation.RecommendedPlaces;
 import com.f12.moitz.infrastructure.client.kakao.KakaoMapAsyncClient;
 import com.f12.moitz.infrastructure.client.kakao.dto.KakaoApiResponse;
@@ -43,10 +44,14 @@ class PlaceRecommenderParallelAdapterTest {
                 new KakaoPlaceMapper()
         );
         given(kakaoMapAsyncClient.searchPlacesByAsync(any(SearchPlacesLimitQuantityRequest.class)))
-                .willReturn(Mono.just(new KakaoApiResponse(
-                        createDocuments(),
-                        new MetaResponse(true, 0, 0, null)
-                )));
+                .willAnswer(invocation -> {
+                    final SearchPlacesLimitQuantityRequest request = invocation.getArgument(0);
+                    final int count = "PC방".equals(request.query()) ? 2 : 6;
+                    return Mono.just(new KakaoApiResponse(
+                            createDocuments(request.query(), count),
+                            new MetaResponse(true, 0, 0, null)
+                    ));
+                });
 
         final Map<Place, RecommendedPlaces> recommendedPlaces = adapter.recommendPlaces(
                 List.of(place),
@@ -59,17 +64,27 @@ class PlaceRecommenderParallelAdapterTest {
         assertThat(captor.getAllValues())
                 .extracting(SearchPlacesLimitQuantityRequest::size)
                 .containsOnly(6);
-        assertThat(recommendedPlaces.get(place).getPlaces(RecommendCondition.PC_ROOM_KARAOKE)).hasSize(6);
+        assertThat(recommendedPlaces.get(place).getPlaces(RecommendCondition.PC_ROOM_KARAOKE))
+                .hasSize(6)
+                .extracting(RecommendedPlace::getName)
+                .containsExactly(
+                        "PC방 장소 0",
+                        "노래방 장소 0",
+                        "PC방 장소 1",
+                        "노래방 장소 1",
+                        "노래방 장소 2",
+                        "노래방 장소 3"
+                );
     }
 
-    private List<DocumentResponse> createDocuments() {
-        return IntStream.range(0, 6)
+    private List<DocumentResponse> createDocuments(final String keyword, final int count) {
+        return IntStream.range(0, count)
                 .mapToObj(index -> new DocumentResponse(
                         "FD6",
                         "음식점 > 카페",
                         "100",
-                        "추천 장소 " + index,
-                        "https://place.map.kakao.com/" + index,
+                        keyword + " 장소 " + index,
+                        "https://place.map.kakao.com/" + keyword + "-" + index,
                         "127.027",
                         "37.497",
                         "https://example.com/image-" + index + ".jpg"

--- a/backend/src/test/java/com/f12/moitz/infrastructure/adapter/place/PlaceRecommenderParallelAdapterTest.java
+++ b/backend/src/test/java/com/f12/moitz/infrastructure/adapter/place/PlaceRecommenderParallelAdapterTest.java
@@ -36,8 +36,39 @@ class PlaceRecommenderParallelAdapterTest {
     private KakaoMapAsyncClient kakaoMapAsyncClient;
 
     @Test
-    @DisplayName("카카오맵 장소 추천 검색 요청 개수를 6개로 제한한다")
-    void recommendPlaces_WithSixPlaceRecommendationCount() {
+    @DisplayName("카카오맵 키워드별 검색 요청 개수를 조건별 제한 개수로 전달한다")
+    void recommendPlaces_PassesLimitPerConditionToEachKeywordRequest() {
+        final Place place = new Place("강남역", new Point(127.027, 37.497));
+        final PlaceRecommenderParallelAdapter adapter = new PlaceRecommenderParallelAdapter(
+                kakaoMapAsyncClient,
+                new KakaoPlaceMapper()
+        );
+        given(kakaoMapAsyncClient.searchPlacesByAsync(any(SearchPlacesLimitQuantityRequest.class)))
+                .willAnswer(invocation -> {
+                    final SearchPlacesLimitQuantityRequest request = invocation.getArgument(0);
+                    final int count = "PC방".equals(request.query()) ? 2 : 6;
+                    return Mono.just(new KakaoApiResponse(
+                            createDocuments(request.query(), count),
+                            new MetaResponse(true, 0, 0, null)
+                    ));
+                });
+
+        adapter.recommendPlaces(
+                List.of(place),
+                new PlaceRecommendationCriteria(List.of(RecommendCondition.PC_ROOM_KARAOKE), 6)
+        );
+
+        final ArgumentCaptor<SearchPlacesLimitQuantityRequest> captor =
+                ArgumentCaptor.forClass(SearchPlacesLimitQuantityRequest.class);
+        verify(kakaoMapAsyncClient, times(2)).searchPlacesByAsync(captor.capture());
+        assertThat(captor.getAllValues())
+                .extracting(SearchPlacesLimitQuantityRequest::size)
+                .containsOnly(6);
+    }
+
+    @Test
+    @DisplayName("PC방·노래방 결과를 라운드로빈으로 인터리브하여 최대 6개를 반환한다")
+    void recommendPlaces_InterleavesMultiKeywordResultsRoundRobin() {
         final Place place = new Place("강남역", new Point(127.027, 37.497));
         final PlaceRecommenderParallelAdapter adapter = new PlaceRecommenderParallelAdapter(
                 kakaoMapAsyncClient,
@@ -58,12 +89,6 @@ class PlaceRecommenderParallelAdapterTest {
                 new PlaceRecommendationCriteria(List.of(RecommendCondition.PC_ROOM_KARAOKE), 6)
         );
 
-        final ArgumentCaptor<SearchPlacesLimitQuantityRequest> captor =
-                ArgumentCaptor.forClass(SearchPlacesLimitQuantityRequest.class);
-        verify(kakaoMapAsyncClient, times(2)).searchPlacesByAsync(captor.capture());
-        assertThat(captor.getAllValues())
-                .extracting(SearchPlacesLimitQuantityRequest::size)
-                .containsOnly(6);
         assertThat(recommendedPlaces.get(place).getPlaces(RecommendCondition.PC_ROOM_KARAOKE))
                 .hasSize(6)
                 .extracting(RecommendedPlace::getName)
@@ -80,8 +105,8 @@ class PlaceRecommenderParallelAdapterTest {
     private List<DocumentResponse> createDocuments(final String keyword, final int count) {
         return IntStream.range(0, count)
                 .mapToObj(index -> new DocumentResponse(
-                        "FD6",
-                        "음식점 > 카페",
+                        "CT1",
+                        "문화,예술 > 오락시설 > " + keyword,
                         "100",
                         keyword + " 장소 " + index,
                         "https://place.map.kakao.com/" + keyword + "-" + index,

--- a/backend/src/test/java/com/f12/moitz/infrastructure/adapter/place/PlaceRecommenderParallelAdapterTest.java
+++ b/backend/src/test/java/com/f12/moitz/infrastructure/adapter/place/PlaceRecommenderParallelAdapterTest.java
@@ -1,0 +1,80 @@
+package com.f12.moitz.infrastructure.adapter.place;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.f12.moitz.application.port.place.PlaceRecommendationCriteria;
+import com.f12.moitz.domain.place.Place;
+import com.f12.moitz.domain.place.Point;
+import com.f12.moitz.domain.recommendation.RecommendCondition;
+import com.f12.moitz.domain.recommendation.RecommendedPlaces;
+import com.f12.moitz.infrastructure.client.kakao.KakaoMapAsyncClient;
+import com.f12.moitz.infrastructure.client.kakao.dto.KakaoApiResponse;
+import com.f12.moitz.infrastructure.client.kakao.dto.DocumentResponse;
+import com.f12.moitz.infrastructure.client.kakao.dto.MetaResponse;
+import com.f12.moitz.infrastructure.client.kakao.dto.SearchPlacesLimitQuantityRequest;
+import com.f12.moitz.infrastructure.utils.KakaoPlaceMapper;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+
+@ExtendWith(MockitoExtension.class)
+class PlaceRecommenderParallelAdapterTest {
+
+    @Mock
+    private KakaoMapAsyncClient kakaoMapAsyncClient;
+
+    @Test
+    @DisplayName("카카오맵 장소 추천 검색 요청 개수를 6개로 제한한다")
+    void recommendPlaces_WithSixPlaceRecommendationCount() {
+        final Place place = new Place("강남역", new Point(127.027, 37.497));
+        final PlaceRecommenderParallelAdapter adapter = new PlaceRecommenderParallelAdapter(
+                kakaoMapAsyncClient,
+                new KakaoPlaceMapper()
+        );
+        given(kakaoMapAsyncClient.searchPlacesByAsync(any(SearchPlacesLimitQuantityRequest.class)))
+                .willReturn(Mono.just(new KakaoApiResponse(
+                        createDocuments(),
+                        new MetaResponse(true, 0, 0, null)
+                )));
+
+        final Map<Place, RecommendedPlaces> recommendedPlaces = adapter.recommendPlaces(
+                List.of(place),
+                new PlaceRecommendationCriteria(List.of(RecommendCondition.PC_ROOM_KARAOKE), 6)
+        );
+
+        final ArgumentCaptor<SearchPlacesLimitQuantityRequest> captor =
+                ArgumentCaptor.forClass(SearchPlacesLimitQuantityRequest.class);
+        verify(kakaoMapAsyncClient, times(2)).searchPlacesByAsync(captor.capture());
+        assertThat(captor.getAllValues())
+                .extracting(SearchPlacesLimitQuantityRequest::size)
+                .containsOnly(6);
+        assertThat(recommendedPlaces.get(place).getPlaces(RecommendCondition.PC_ROOM_KARAOKE)).hasSize(6);
+    }
+
+    private List<DocumentResponse> createDocuments() {
+        return IntStream.range(0, 6)
+                .mapToObj(index -> new DocumentResponse(
+                        "FD6",
+                        "음식점 > 카페",
+                        "100",
+                        "추천 장소 " + index,
+                        "https://place.map.kakao.com/" + index,
+                        "127.027",
+                        "37.497",
+                        "https://example.com/image-" + index + ".jpg"
+                ))
+                .toList();
+    }
+
+}


### PR DESCRIPTION
## 🕹️ 작업 내용

한 줄 요약 : 추천 지역별 단일 태그 매핑으로 변경하고, 응답 정보와 정렬 기준을 조정

- [x] 추천 지역이 여러 태그를 갖지 않고 태그당 하나의 추천 지역만 대응되도록 변경
- [x] 추천 응답에 tag_info, location_info 필드 추가
- [x] 추천 지역 정렬 기준을 태그 선언 순서에서 공평성 점수 우선으로 변경 -> 고정되지 않도록 수정
- [x] 추천 장소 개수를 5개에서 6개로 증가 (이전에 언급한대로 짝수로 수정)

## 📋 리뷰 포인트

- 태그 중복 후보가 발생했을 때 다음 후보를 선택하는 정책이 의도와 맞는지

## 🔮 기타 사항

- 추후 FE 적용 이후 미사용 description, reason 필드를 응답에서 제거해야 함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 위치 추천 응답에 다중 태그 지원 및 태그/위치 설명(tag_info, location_info) 추가로 추천 이유가 명확해졌습니다.
  * 추천 정렬을 공평성 점수 우선으로 변경하여 더 균형 잡힌 추천 순서를 제공합니다.
  * 장소 추천 시 조건별 제한을 도입해 per-condition 추천 수를 제어합니다.
* **테스트**
  * 태그 정규화 및 직렬화 관련 단위/통합 테스트가 추가·갱신되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->